### PR TITLE
mdiag has bash-specific syntax, so use #!/bin/bash

### DIFF
--- a/mdiag/mdiag.sh
+++ b/mdiag/mdiag.sh
@@ -44,7 +44,7 @@
 # limitations under the License.
 
 
-version="1.6.0"
+version="1.6.1"
 
 diagfile="/tmp/mdiag-`hostname`.txt"
 


### PR DESCRIPTION
See full rationale in the first commit.
