### PR TITLE
Added ip_neigh - ip neigh check

### DIFF
--- a/mdiag/mdiag.sh
+++ b/mdiag/mdiag.sh
@@ -226,6 +226,7 @@ msection ip_link ip link
 msection ip_addr ip addr
 msection ip_route ip route
 msection ip_rule ip rule
+msection ip_neigh ip neigh
 msection hosts getfiles /etc/hosts
 msection host.conf getfiles /etc/host.conf
 msection resolv getfiles /etc/resolv.conf


### PR DESCRIPTION
Interesting blog (http://engineering.clever.com/2014/12/10/when-your-ip-traffic-in-aws-disappears-into-a-black-hole/) pointed out that ARP tables in AWS can be cached and reflect stale MACs from non-current boxes. Added ip neigh check to highlight STALE or REACHABLE states.
