### PR TITLE
mdiag.sh: tolerate being in DOS format (CR/LFs)

### DIFF
--- a/mdiag/mdiag.sh
+++ b/mdiag/mdiag.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# The following 2 lines make "bash mdiag.sh ..." work even if the file is in DOS format (with CR/LFs).
+eval "`echo -ne '\r'`() { sed 's/\x0D$//' '$0' | '$BASH' -s -- "'"${a[@]}" ; exit $?; }'; a=("$@");
+unset a
 
 # ===================================
 # mdiag.sh: MongoDB Diagnostic Report


### PR DESCRIPTION
For example, this can come about if the script is downloaded in a browser in
Windows, and then transferred (in binary mode) to the Linux host.