### PR TITLE
DEBUG: in the readme the order of the parameters was wrong, this way it ...

### DIFF
--- a/getMongoData/README.md
+++ b/getMongoData/README.md
@@ -18,7 +18,7 @@ To execute on a locally running `mongod` on default port (27017) without authent
 
 To execute on a remote `mongod` or `mongos` with authentication, run:
 
-    mongo --quiet --norc getMongoData.js HOST:PORT/admin -u ADMIN_USER -p ADMIN_PASSWORD > getMongoData.log
+    mongo HOST:PORT/admin -u ADMIN_USER -p ADMIN_PASSWORD --quiet --norc getMongoData.js > getMongoData.log
 
 If `ADMIN_PASSWORD` is omitted, the shell will prompt for the password.
 

--- a/mdiag/mdiag.sh
+++ b/mdiag/mdiag.sh
@@ -276,6 +276,13 @@ done
 msection global_mongodb_conf getfiles /etc/mongodb.conf /etc/mongod.conf
 msection global_mms_conf getfiles /etc/mongodb-mms/*
 
+#check numa capabilities and alignment
+msection numactl <<EOF
+which numactl && echo "numactl is INSTALLED" || echo "numactl is NOT installed";
+msubsection Hardware numactl --hardware 2> /dev/null;
+msubsection Show numactl --show 2> /dev/null;
+EOF
+
 # Hardware info with a risk of hanging
 msection smartctl <<EOF
 smartctl --scan | sed -e "s/#.*$//" | while read i; do smartctl --all \$i; done


### PR DESCRIPTION
Chaned the order of the params in the readme, while in the original one, it is wrong:
the HOST:PORT/DB should be the first one otherwise it will not be parsed.