### PR TITLE
added fusionIO and HP smartarray information collection

### DIFF
--- a/mdiag/mdiag.sh
+++ b/mdiag/mdiag.sh
@@ -289,6 +289,16 @@ smartctl --scan | sed -e "s/#.*$//" | while read i; do smartctl --all \$i; done
 EOF
 msection scsidevices getfiles /sys/bus/scsi/devices/*/model
 
+#storage detail collection
+#FusionIO
+msection fusionio fio-status -fj 2> /dev/null
+
+#HP smart array
+msection HPsmartArray <<EOF 
+msubsection hpacucli hpacucli ctrl all show config detail 2> /dev/null
+msubsection hpssacli hpssacli ctrl all show config detail 2> /dev/null
+EOF
+
 cat <<EOF
 
 ==============================================================


### PR DESCRIPTION
Hi, 

This request contains, the most verbose output which is able to be gathered from two types of storage devices: FusionIO, HP SmartArray. I know about at least one customer of yours who is using both. Maybe  others using one of them. Unfortunately will conflict with my other pull request on merge. But no real conflicting change, just overlap on lines. I can merge upfront the first accepted pull request to the other one. I gladly address any concerns just bash me. :)

Best,
Attish