### PR TITLE
mdiag: Fix fragility from using "<<-" construct.

### DIFF
--- a/mdiag/mdiag.sh
+++ b/mdiag/mdiag.sh
@@ -267,15 +267,15 @@ msection iostat iostat -xtm 1 120
 mongo_pids="`pgrep mongo`"
 msection mongo_summary ps -Fww -p $mongo_pids
 for pid in $mongo_pids; do
-	msection proc/$pid <<-EOF
-	lsfiles /proc/$pid/cmdline
-	msubsection cmdline xargs -n1 -0 < /proc/$pid/cmdline
-	xargs -n1 -0 < /proc/$pid/cmdline | awk '\$0 == "-f" || \$0 == "--config" { getline; print; }' | getstdinfiles
-	getfiles /proc/$pid/limits /proc/$pid/mounts /proc/$pid/mountinfo /proc/$pid/smaps /proc/$pid/numa_maps
-	lsfiles /proc/$pid/fd 
-	getfiles /proc/$pid/fdinfo/*
-	getfiles /proc/$pid/cgroup
-	EOF
+msection proc/$pid <<EOF
+lsfiles /proc/$pid/cmdline
+msubsection cmdline xargs -n1 -0 < /proc/$pid/cmdline
+xargs -n1 -0 < /proc/$pid/cmdline | awk '\$0 == "-f" || \$0 == "--config" { getline; print; }' | getstdinfiles
+getfiles /proc/$pid/limits /proc/$pid/mounts /proc/$pid/mountinfo /proc/$pid/smaps /proc/$pid/numa_maps
+lsfiles /proc/$pid/fd 
+getfiles /proc/$pid/fdinfo/*
+getfiles /proc/$pid/cgroup
+EOF
 done
 msection global_mongodb_conf getfiles /etc/mongodb.conf /etc/mongod.conf
 msection global_mms_conf getfiles /etc/mongodb-mms/*


### PR DESCRIPTION
The "<<-" here-document construct is a bash feature that will strip leading tab
characters when processing the following lines, including when looking for the
EOF marker.  Unfortunately, if the script has accidentally been mangled such
that the tab characters are converted to spaces, this means the script will
abort at this point with "unexpected end of file".  This causes the output to
be incomplete.

This patch fixes that problem by switching to a regular "<<" here-document, and
removing the indentation.  This comes at a small cost to the readability of
that section of code.  There are no longer any uses of "<<-", meaning that this
version of the script is no longer susceptible to this problem.