### PR TITLE
Add support for outputing in a JSON format

### DIFF
--- a/getMongoData/README.md
+++ b/getMongoData/README.md
@@ -22,6 +22,10 @@ To execute on a remote `mongod` or `mongos` with authentication, run:
 
 If `ADMIN_PASSWORD` is omitted, the shell will prompt for the password.
 
+To have the output be in a JSON format, modify the above commands to include the following eval argument,
+as demonstrated for the local execution:
+
+    mongo --quiet --norc --eval "var _printJSON=true" getMongoData.js > getMongoData.json
 
 ### License
 

--- a/getMongoData/README.md
+++ b/getMongoData/README.md
@@ -25,7 +25,7 @@ If `ADMIN_PASSWORD` is omitted, the shell will prompt for the password.
 To have the output be in a JSON format, modify the above commands to include the following eval argument,
 as demonstrated for the local execution:
 
-    mongo --quiet --norc --eval "var _printJSON=true" getMongoData.js > getMongoData.json
+    mongo --quiet --norc --eval "var _printJSON=true; var _ref = 'CS-XXXXX'" getMongoData.js > getMongoData-output.json
 
 ### License
 

--- a/getMongoData/getMongoData.js
+++ b/getMongoData/getMongoData.js
@@ -199,8 +199,8 @@ function printInfo(message, command, section, printResult) {
     doc['error'] = err;
     doc['host'] == _host;
     doc['ref'] == ""; // TODO cli speficied?
-    doc['rid'] = _runId;
-    doc['run'] = _runId.getTimestamp();
+    doc['tag'] = _tag;
+    doc['run'] = _tag.getTimestamp();
     doc['output'] = result;
     if (typeof(section) !== "undefined") {
         doc['section'] = section;
@@ -306,7 +306,7 @@ function printAuthInfo() {
 
 if (typeof _printJSON === "undefined") var _printJSON = false;
 var _output = [];
-var _runId = ObjectId();
+var _tag = ObjectId();
 if (! _printJSON) {
     print("================================");
     print("MongoDB Config and Schema Report");

--- a/getMongoData/getMongoData.js
+++ b/getMongoData/getMongoData.js
@@ -175,7 +175,7 @@ function printShardInfo(){
 function printInfo(message, command, section, printResult) {
     var result = false;
     printResult = (printResult === undefined ? true : false);
-    if (_printOutput) print("\n** " + message + ":");
+    if (! _printJSON) print("\n** " + message + ":");
     startTime = new Date();
     try {
         if (typeof(command) == "string") {
@@ -187,7 +187,7 @@ function printInfo(message, command, section, printResult) {
         }
         err = null
     } catch(err) {
-        if (_printOutput) {
+        if (! _printJSON) {
             print("Error running '" + command + "':");
             print(err);
         }
@@ -211,7 +211,7 @@ function printInfo(message, command, section, printResult) {
     doc['ts'] = {'start': startTime, 'end': endTime};
     doc['version'] = _version;
     _output.push(doc);
-    if (_printOutput && printResult) printjson(result);
+    if (! _printJSON && printResult) printjson(result);
     return result;
 }
 
@@ -283,7 +283,7 @@ function printShardOrReplicaSetInfo() {
         }
         if ( ! state ) state = "standalone";
     }
-    if (_printOutput) print("\n** Connected to " + state);
+    if (! _printJSON) print("\n** Connected to " + state);
     if (state == "mongos") {
         printShardInfo();
         return true;
@@ -304,10 +304,10 @@ function printAuthInfo() {
 }
 
 
-var _printOutput = true;
+if (typeof _printJSON === "undefined") var _printJSON = false;
 var _output = [];
 var _runId = ObjectId();
-if (_printOutput) {
+if (! _printJSON) {
     print("================================");
     print("MongoDB Config and Schema Report");
     print("getMongoData.js version " + _version);
@@ -318,4 +318,4 @@ printServerInfo();
 var isMongoS = printShardOrReplicaSetInfo();
 printAuthInfo();
 printDataInfo(isMongoS);
-if (! _printOutput) printjson(_output);
+if (_printJSON) printjson(_output);


### PR DESCRIPTION
Add support for outputing in a JSON format. This is done via an eval argument as shown in the README. Run as before, the output will be almost exactly the same, except that the Shards and Sharded databases sections will have a little more structure.