### PR TITLE
Adding checks for NTPD and for CHRONY network time

### DIFF
--- a/mdiag/mdiag.sh
+++ b/mdiag/mdiag.sh
@@ -238,6 +238,14 @@ msection networks getfiles /etc/networks
 msection rpcinfo rpcinfo -p
 msection netstat netstat -anpoe
 
+# Network time info
+msection ntpd_configuration chkconfig --list ntpd
+msection ntpd_status ntpstat
+msection ntpd_timeinfo ntpq -p
+msection chronyc_tracking chronyc tracking
+msection chronyc_sources chronyc sources
+msection chronyc_sourcestats chronyc sourcestats
+
 # Hardware info
 msection dmesg dmesg
 msection lspci lspci -vvv


### PR DESCRIPTION
This is to add functionality to check for the common network time daemon, NTPD and CHRONYC and to gather the specific time information that these are reflecting to the current host.

This information can be used to ensure that the system's time in kept in synchronization with time servers using the Network Time Protocol and to diagnose any potential issues from differing clock times.

### NTPD
* chkconfig --list ntpd : specifies the runlevel the ntpd service is run at
* ntpstat : provides a short synchronisation state of the NTP daemon running on the host
* ntpq -p : queries the local NTP daemon to provide details about its peers

### Chronyc
* chronyc tracking : provides the time details for host, reference host, stratum, etc.
* chronyc sources : provides statistics and details on the current time sources that chronyd is accessing
* chronyc sourcestats : describes the drift rate and offset estimation process for each of the sources currently being examined by chronyd