### PR TITLE
Adding check for the type of storage device SSD/HDD

### DIFF
--- a/mdiag/mdiag.sh
+++ b/mdiag/mdiag.sh
@@ -220,6 +220,7 @@ msection lvm_lvdisplay lvdisplay -am
 msection nr_requests getfilesfromcommand find /sys -name nr_requests
 msection read_ahead_kb getfilesfromcommand find /sys -name read_ahead_kb
 msection scheduler getfilesfromcommand find /sys -name scheduler
+msection rotational getfilesfromcommand find /sys -name rotational
 
 # Network info
 msection ifconfig ifconfig -a


### PR DESCRIPTION
This check will query the *rotational* field from  /sys/block/<device>/queue/rotational to determine whether this is a SSD (0) or HDD (1).
Additional information on this parameter can be found in http://lwn.net/Articles/408428/ and https://www.kernel.org/doc/Documentation/block/queue-sysfs.txt

This check will allow the determination of what storage devices are being used on the host, specifically it can be used with knowledge of the MongoDB _dbpath_ and the mounts to provide the most appropriate readahead setting recommendations depending on the device type.