### PR TITLE
Added parameter to disable the collection of sample documents

### DIFF
--- a/getMongoData/README.md
+++ b/getMongoData/README.md
@@ -27,6 +27,10 @@ as demonstrated for the local execution:
 
     mongo --quiet --norc --eval "var _printJSON=true; var _ref = 'CS-XXXXX'" getMongoData.js > getMongoData-output.json
 
+By default, the outut will include a sample document from each non-system collection.  To disable this, include `_excludeDocs` argument as shown below:
+
+    mongo --quiet --norc --eval "var _printJSON=true; var _excludeDocs=true" getMongoData.js > getMongoData-output.json
+
 ### License
 
 [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/getMongoData/getMongoData.js
+++ b/getMongoData/getMongoData.js
@@ -89,7 +89,7 @@ if (DB.prototype.getRoles == null) {
 }
 
 // Taken from the >= 3.1.9 shell to capture print output
-if (typeof print.captureAllOutput === "undefined") { 
+if (typeof print.captureAllOutput === "undefined") {
     print.captureAllOutput = function (fn, args) {
         var res = {};
         res.output = [];
@@ -302,7 +302,7 @@ function printDataInfo(isMongoS) {
                     }
                     printInfo('Indexes',
                               function(){return db.getSiblingDB(mydb.name).getCollection(col).getIndexes()}, section);
-                    if (col != "system.users") {
+                    if (col != "system.users" && !_excludeDocs) {
                         printInfo('Sample document',
                                   function(){
 					var lastValCursor = db.getSiblingDB(mydb.name).getCollection(col).find().sort({'$natural': -1}).limit(-1);
@@ -358,6 +358,7 @@ function printAuthInfo() {
 
 if (typeof _printJSON === "undefined") var _printJSON = false;
 if (typeof _ref === "undefined") var _ref = null;
+if (typeof _excludeDocs === "undefined") var _excludeDocs = false;
 var _output = [];
 var _tag = ObjectId();
 if (! _printJSON) {


### PR DESCRIPTION
Added a parameter to allow users of the script to disable the collection of sample documents.  This is required to allow diagnostic data to be extracted without potentially sensitive data being included that would otherwise need redacting. 