### PR TITLE
Now pulling indexStats information

### DIFF
--- a/getMongoData/getMongoData.js
+++ b/getMongoData/getMongoData.js
@@ -89,7 +89,7 @@ if (DB.prototype.getRoles == null) {
 }
 
 // Taken from the >= 3.1.9 shell to capture print output
-if (typeof print.captureAllOutput === "undefined") { 
+if (typeof print.captureAllOutput === "undefined") {
     print.captureAllOutput = function (fn, args) {
         var res = {};
         res.output = [];
@@ -303,25 +303,27 @@ function printDataInfo(isMongoS) {
                     printInfo('Indexes',
                               function(){return db.getSiblingDB(mydb.name).getCollection(col).getIndexes()}, section);
                     printInfo('Index Stats',
-                              function(){var res = db.getSiblingDB(mydb.name).runCommand( {
-                                aggregate: col,
-                                pipeline: [
-                                  {$indexStats: {}},
-                                  {$group: {_id: "$key", stats: {$push: {accesses: "$accesses.ops", host: "$host", since: "$accesses.since"}}}},
-                                  {$project: {key: "$_id", stats: 1, _id: 0}}
-                                ]});
+                              function(){
+                                var res = db.getSiblingDB(mydb.name).runCommand( {
+                                  aggregate: col,
+                                  pipeline: [
+                                    {$indexStats: {}},
+                                    {$group: {_id: "$key", stats: {$push: {accesses: "$accesses.ops", host: "$host", since: "$accesses.since"}}}},
+                                    {$project: {key: "$_id", stats: 1, _id: 0}}
+                                  ]
+                                });
 
-                              if (res.hasOwnProperty('result')) {
-                                res.result.forEach(
-                                  function(d){
-                                    d.stats.map(
-                                      function(d){
-                                        return d.since = d.since.toUTCString();
-                                      })
+                                if (res.hasOwnProperty('result')) {
+                                  res.result.forEach(
+                                    function(d){
+                                      d.stats.forEach(
+                                        function(d){
+                                          d.since = d.since.toUTCString();
+                                        })
                                     });
-                              }
+                                }
 
-                              return res;
+                                return res;
                               }, section);
                     if (col != "system.users") {
                         printInfo('Sample document',

--- a/getMongoData/getMongoData.js
+++ b/getMongoData/getMongoData.js
@@ -302,6 +302,27 @@ function printDataInfo(isMongoS) {
                     }
                     printInfo('Indexes',
                               function(){return db.getSiblingDB(mydb.name).getCollection(col).getIndexes()}, section);
+                    printInfo('Index Stats',
+                              function(){var res = db.getSiblingDB(mydb.name).runCommand( {
+                                aggregate: col,
+                                pipeline: [
+                                  {$indexStats: {}},
+                                  {$group: {_id: "$key", stats: {$push: {accesses: "$accesses.ops", host: "$host", since: "$accesses.since"}}}},
+                                  {$project: {key: "$_id", stats: 1, _id: 0}}
+                                ]});
+
+                              if (res.hasOwnProperty('result')) {
+                                res.result.forEach(
+                                  function(d){
+                                    d.stats.map(
+                                      function(d){
+                                        return d.since = d.since.toUTCString();
+                                      })
+                                    });
+                              }
+
+                              return res;
+                              }, section);
                     if (col != "system.users") {
                         printInfo('Sample document',
                                   function(){


### PR DESCRIPTION
Added output from $indexStats.
Using runCommand instead of aggregate in order to catch errors when server does not support $indexStats or we don't have correct permissions.