### PR TITLE
Updated to support MongoD 3.6

### DIFF
--- a/getMongoData/getMongoData.js
+++ b/getMongoData/getMongoData.js
@@ -314,6 +314,9 @@ function printDataInfo(isMongoS) {
                                   cursor: {}
                                 });
 
+                                //It is assumed that there always will be a single batch as collections
+                                //are limited to 64 indexes and usage from all shards is grouped
+                                //into a single document
                                 if (res.hasOwnProperty('cursor') && res.cursor.hasOwnProperty('firstBatch')) {
                                   res.cursor.firstBatch.forEach(
                                     function(d){

--- a/getMongoData/getMongoData.js
+++ b/getMongoData/getMongoData.js
@@ -310,7 +310,8 @@ function printDataInfo(isMongoS) {
                                     {$indexStats: {}},
                                     {$group: {_id: "$key", stats: {$push: {accesses: "$accesses.ops", host: "$host", since: "$accesses.since"}}}},
                                     {$project: {key: "$_id", stats: 1, _id: 0}}
-                                  ]
+                                  ],
+                                  cursor: {}
                                 });
 
                                 if (res.hasOwnProperty('result')) {

--- a/getMongoData/getMongoData.js
+++ b/getMongoData/getMongoData.js
@@ -314,8 +314,8 @@ function printDataInfo(isMongoS) {
                                   cursor: {}
                                 });
 
-                                if (res.hasOwnProperty('result')) {
-                                  res.result.forEach(
+                                if (res.hasOwnProperty('cursor') && res.cursor.hasOwnProperty('firstBatch')) {
+                                  res.cursor.firstBatch.forEach(
                                     function(d){
                                       d.stats.forEach(
                                         function(d){


### PR DESCRIPTION
MongoDB 3.6 removes the use of aggregate command without the cursor option unless the command includes the explain option