### PR TITLE
Use tested and expanded path

### DIFF
--- a/ssl-windows/Convert-PfxToPem.ps1
+++ b/ssl-windows/Convert-PfxToPem.ps1
@@ -169,7 +169,25 @@ Add-Type @'
 '@
 try
 {
-   if (-not ($cert = New-Object Security.Cryptography.X509Certificates.X509Certificate2($PFXFile, $Passphrase, 'Exportable')))
+   if (Test-Path -Path $PFXFile -PathType Leaf)
+   {
+      $pfxPath = (Get-Item -Path $PFXFile).FullName
+   }
+   else
+   {
+      Write-Warning "Unable to find PFX file $PFXFile"
+      Exit
+   }
+}
+catch
+{
+   Write-Warning "Unable to acces PFX file $PFXFile"
+   Exit
+}
+
+try
+{
+   if (-not ($cert = New-Object Security.Cryptography.X509Certificates.X509Certificate2($pfxPath, $Passphrase, 'Exportable')))
    {
       Write-Warning "Unable to load certificate $PFXFile"
       Exit


### PR DESCRIPTION
Second PR for a tweak that I personally had a need for. It allows use of _filename in current working dir_ as `PFXFile` instead of only full path required by `X509Certificate2.'ctor.`.