### PR TITLE
TSPROJ-5207: Add sharding settings and routers to ouput for a mongos

### DIFF
--- a/getMongoData/getMongoData.js
+++ b/getMongoData/getMongoData.js
@@ -118,9 +118,17 @@ function printShardInfo(){
     section = "shard_info";
     var configDB = db.getSiblingDB("config");
 
-    printInfo("Sharding version",
-              function(){return db.getSiblingDB("config").getCollection("version").findOne()},
-              section);
+    printInfo("Sharding version", function(){
+        return configDB.getCollection('version').findOne();
+    }, section);
+
+    printInfo("Sharding settings", function(){
+        return configDB.settings.find().sort({ _id : 1 }).toArray();
+    }, section);
+
+    printInfo("Routers", function(){
+        return configDB.mongos.find().sort({ _id : 1 }).toArray();
+    }, section);
 
     printInfo("Shards", function(){
         return configDB.shards.find().sort({ _id : 1 }).toArray();


### PR DESCRIPTION
Added the following to the getMongoData output for a mongos router:

* config database's "settings" collection
* config database's "mongos" collection

Also includes a minor stylistic change to the "Sharding version" section to be more parallel to the surrounding code (note that the 'version' collection name is special so "getCollection()" needs to be used.
