### PR TITLE
Remove the full details of chunk distribution by default

### DIFF
--- a/getMongoData/README.md
+++ b/getMongoData/README.md
@@ -27,7 +27,7 @@ as demonstrated for the local execution:
 
     mongo --quiet --norc --eval "var _printJSON=true; var _ref = 'CS-XXXXX'" getMongoData.js > getMongoData-output.json
 
-To have the output include the full details of chunk distribution across shards, include `var _printChunkDetails=true` in the `--eval` option.
+For sharded clusters to have the output include the full details of chunk distribution across shards, include `var _printChunkDetails=true` in the `--eval` option.
 
 ### License
 

--- a/getMongoData/README.md
+++ b/getMongoData/README.md
@@ -27,6 +27,8 @@ as demonstrated for the local execution:
 
     mongo --quiet --norc --eval "var _printJSON=true; var _ref = 'CS-XXXXX'" getMongoData.js > getMongoData-output.json
 
+To have the output include the full details of chunk distribution across shards, include `var _printChunkDetails=true` in the `--eval` option.
+
 ### License
 
 [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/getMongoData/getMongoData.js
+++ b/getMongoData/getMongoData.js
@@ -165,17 +165,19 @@ function printShardInfo(){
                                     collDoc['distribution'].push(chunkDistDoc);
                                 } );
 
-                                collDoc['chunks'] = [];
-                                configDB.chunks.find( { "ns" : coll._id } ).sort( { min : 1 } ).forEach(
-                                    function(chunk) {
-                                        chunkDoc = {}
-                                        chunkDoc['min'] = chunk.min;
-                                        chunkDoc['max'] = chunk.max;
-                                        chunkDoc['shard'] = chunk.shard;
-                                        chunkDoc['jumbo'] = chunk.jumbo ? true : false;
-                                        collDoc['chunks'].push(chunkDoc);
-                                    }
-                                );
+				if (_printChunkDetails) {
+                                    collDoc['chunks'] = [];
+                                    configDB.chunks.find( { "ns" : coll._id } ).sort( { min : 1 } ).forEach(
+					function(chunk) {
+                                            chunkDoc = {}
+                                            chunkDoc['min'] = chunk.min;
+                                            chunkDoc['max'] = chunk.max;
+                                            chunkDoc['shard'] = chunk.shard;
+                                            chunkDoc['jumbo'] = chunk.jumbo ? true : false;
+                                            collDoc['chunks'].push(chunkDoc);
+					}
+                                    );
+				}
 
                                 collDoc['tags'] = [];
                                 configDB.tags.find( { ns : coll._id } ).sort( { min : 1 } ).forEach(
@@ -360,6 +362,7 @@ function printShardOrReplicaSetInfo() {
 }
 
 if (typeof _printJSON === "undefined") var _printJSON = false;
+if (typeof _printChunkDetails === "undefined") var _printChunkDetails = false;
 if (typeof _ref === "undefined") var _ref = null;
 
 // Limit the number of collections this script gathers stats on in order


### PR DESCRIPTION
Removes the full details of chunk distribution unless "var _printChunkDetails=true" is passed into "--eval".