### PR TITLE
STAR-3215 Automatically check for rollover of local.system.healthlog on all nodes

### DIFF
--- a/replset-consistency/README.md
+++ b/replset-consistency/README.md
@@ -142,6 +142,8 @@ It is important to check on all nodes as the contents on each node can vary, and
 
 If `local.system.healthlog` does not contain a "dbCheckStart" document for the collection you're running `dbCheck` on, `local.system.healthlog` has rolled over and subsequent scripts will not have complete information. 
 
+If `dbCheck` is run using `dbcheck.js`, you may optionally specify an `authInfo` object, with the user created above, to automatically check if the healthlog has rolled over. Omitting this object will not accurately check if the healthlog has rolled over on each secondary.
+
 When you are ready, run `dbCheck`, specifying a write concern equal to the number of data-bearing nodes (X) in the replica set, and our recommended `wtimeout` of `1000`.
 
 ```

--- a/replset-consistency/README.md
+++ b/replset-consistency/README.md
@@ -142,7 +142,7 @@ It is important to check on all nodes as the contents on each node can vary, and
 
 If `local.system.healthlog` does not contain a "dbCheckStart" document for the collection you're running `dbCheck` on, `local.system.healthlog` has rolled over and subsequent scripts will not have complete information. 
 
-If `dbCheck` is run using `dbcheck.js`, you may optionally specify an `authInfo` object, with the user created above, to automatically check if the healthlog has rolled over. Omitting this object will not accurately check if the healthlog has rolled over on each secondary.
+The `dbcheck.js` script will automatically attempt to check if the healthlog has rolled over. You must specify an `authInfo` object with the user created above to guarantee an accurate check on the completeness of results from all replica set nodes. If you do not specify the `authInfo` object, the healthlog may not be checked on every replica set node, and the results may not be complete. Whether the healthlog has rolled over will be reported in the `rollover` field.
 
 When you are ready, run `dbCheck`, specifying a write concern equal to the number of data-bearing nodes (X) in the replica set, and our recommended `wtimeout` of `1000`.
 

--- a/replset-consistency/dbcheck.js
+++ b/replset-consistency/dbcheck.js
@@ -253,7 +253,7 @@ function checkRollOver() {
   if (weakCheck || !authInfo) {
     printFunction({
       msg: `${
-        !authInfo && "authInfo object is undefined. "
+        !authInfo ? "authInfo object is undefined. " : ""
       }Unable to authenticate into secondary nodes. Performing weak healthlog rollover check.`,
     });
     for (let i = 0; i < ((getWriteConcern() - 1) * 2); i++) {

--- a/replset-consistency/dbcheck.js
+++ b/replset-consistency/dbcheck.js
@@ -252,7 +252,9 @@ function checkRollOver() {
   
   if (weakCheck || !authInfo) {
     printFunction({
-      msg: "authInfo object is undefined; performing weak healthlog rollover check.",
+      msg: `${
+        !authInfo && "authInfo object is undefined. "
+      }Unable to authenticate into secondary nodes. Performing weak healthlog rollover check.`,
     });
     for (let i = 0; i < ((getWriteConcern() - 1) * 2); i++) {
       try {

--- a/replset-consistency/dbcheck.js
+++ b/replset-consistency/dbcheck.js
@@ -406,8 +406,9 @@ var helloDoc = (typeof db.hello !== 'function') ? db.isMaster() : db.hello();
 var lastStartup = new Date(new Date() - db.serverStatus().uptimeMillis);
 sleep(1000); // Not sure this is necessary, but sometimes dbCheck results can
              // appear shortly after the command returns ok.
-
-authInfo.db = authInfo.db || 'local';
+if (authInfo) {
+  authInfo.db = authInfo.db || 'local';
+}
 checkRollOver();
 printFunction({
   dbCheckOk : failArray.length == 0,

--- a/replset-consistency/dbcheck.js
+++ b/replset-consistency/dbcheck.js
@@ -180,9 +180,12 @@ function getDBCheckCountByNode(node) {
   return 0;
 }
 
-// Authenticates into every data-bearing secondary nodes to query 
-// healthlog dbCheckStart entries
-// If authInfo is not provided, defaults to old healthlog rollover check
+// Authenticates into every data-bearing secondary nodes to query healthlog 
+// dbCheckStart entries
+//
+// If authInfo is not provided, behavior defaults to old healthlog rollover check 
+// that is non-deterministic. We don't know if we'll select the same secondary 
+// over and over again.
 //
 function checkRollOver() {
   let config = rs.config();

--- a/replset-consistency/dbcheck.js
+++ b/replset-consistency/dbcheck.js
@@ -23,7 +23,7 @@ Usage:
    Combination of databases and namespaces
     --eval "dbs = ['admin']; ns =
     ['admin.system.version','config.system.sessions']"
-   To ensure a deterministic check for secondary healthlog roll over
+   To guarantee completeness of results on all nodes
     --eval "authInfo={'user': '$user', 'pwd': '$password'}"
 
  This must be run as a user with the following roles:

--- a/replset-consistency/dbcheck.js
+++ b/replset-consistency/dbcheck.js
@@ -205,6 +205,7 @@ function checkRollOver() {
     delete authInfo.uriOptions;
   
     for (let member of config.members) {
+      try {
         let conn = new Mongo("mongodb://" + member.host + "/?" + uriOptions);
         conn.setSecondaryOk(true);
         if (member.arbiterOnly) {
@@ -215,6 +216,14 @@ function checkRollOver() {
             }
             nodelist.push({_id: member._id, connection: conn, host: member.host});
         }
+      } catch (error) {
+        printFunction({
+          msg: "unable to connect to node in replset",
+          error: error,
+          _id: member._id,
+          host: member.host,
+        })
+      }
     }
     
     for (let i = 0; i < nodelist.length; i++) {

--- a/replset-consistency/dbcheck.js
+++ b/replset-consistency/dbcheck.js
@@ -228,7 +228,8 @@ function checkRollOver() {
         }
       } catch (error) {
         printFunction({
-          msg: error,
+          msg: "failed to check node for dbCheck count",
+          error: error,
           _id: nodelist[i]._id,
           host: nodelist[i].host,
         });

--- a/replset-consistency/dbcheck.js
+++ b/replset-consistency/dbcheck.js
@@ -201,7 +201,7 @@ function checkRollOver() {
   }
 
   if (typeof authInfo !== "undefined") {
-    uriOptions = authInfo.uriOptions;
+    uriOptions = authInfo.uriOptions || "";
     delete authInfo.uriOptions;
   
     for (let member of config.members) {

--- a/replset-consistency/dbcheck.js
+++ b/replset-consistency/dbcheck.js
@@ -191,7 +191,7 @@ function checkRollOver() {
   } catch (error) {
     printFunction(error);
   }
-  
+
   for (let member of config.members) {
       let conn = new Mongo("mongodb://" + member.host + "/?" + uriOptions);
       conn.setSecondaryOk(true);
@@ -206,6 +206,7 @@ function checkRollOver() {
   }
   
   for (let i = 0; i < nodelist.length; i++) {
+    let nodeInfo = nodelist[i];
     try {   
       let tcount = getDBCheckCountByNode(nodeInfo)
       if (i == 0) {

--- a/replset-consistency/dbcheck.js
+++ b/replset-consistency/dbcheck.js
@@ -9,11 +9,11 @@ Use this script as part of the guidance in
 https://github.com/mongodb/support-tools/tree/replset-consistency/replset-consistency/README.md
 
 Usage:
-  mongosh mongodb://127.0.0.1:27017/?replicaSet=replset dbcheck.js 2>&1 | tee
-  dbcheckresults.json
+  mongosh mongodb://127.0.0.1:27017/?replicaSet=replset --eval "authInfo={<auth object>}" \ 
+   dbcheck.js 2>&1 | tee dbcheckresults.json
  or
-  mongo mongodb://127.0.0.1:27017/?replicaSet=replset dbcheck.js 2>&1 | tee
-  dbcheckresults.json
+  mongo mongodb://127.0.0.1:27017/?replicaSet=replset --eval "authInfo={<auth object>}" \ 
+   dbcheck.js 2>&1 | tee dbcheckresults.json
 
  Partial results can be found by passing --eval
    To run on a specific list of name spaces.
@@ -23,6 +23,8 @@ Usage:
    Combination of databases and namespaces
     --eval "dbs = ['admin']; ns =
     ['admin.system.version','config.system.sessions']"
+   To ensure a deterministic check for secondary healthlog roll over
+    --eval "authInfo={'user': '$user', 'pwd': '$password'}"
 
  This must be run as a user with the following roles:
    - listDatabases: List all databases

--- a/replset-consistency/dbcheck.js
+++ b/replset-consistency/dbcheck.js
@@ -182,6 +182,7 @@ function getDBCheckCountByNode(node) {
 
 // Authenticates into every data-bearing secondary nodes to query 
 // healthlog dbCheckStart entries
+// If authInfo is not provided, defaults to old healthlog rollover check
 //
 function checkRollOver() {
   let config = rs.config();
@@ -194,7 +195,7 @@ function checkRollOver() {
     printFunction(error);
   }
 
-  if (authInfo) {
+  if (typeof authInfo !== "undefined") {
     uriOptions = authInfo.uriOptions;
     delete authInfo.uriOptions;
   
@@ -225,6 +226,7 @@ function checkRollOver() {
       }
     }
   } else {
+    printFunction("authInfo object is undefined; performing weak healthlog rollover check.")
     for (let i = 0; i < ((getWriteConcern() - 1) * 2); i++) {
       try {
         let tcount = getDBCheckCount("secondary");
@@ -406,7 +408,7 @@ var helloDoc = (typeof db.hello !== 'function') ? db.isMaster() : db.hello();
 var lastStartup = new Date(new Date() - db.serverStatus().uptimeMillis);
 sleep(1000); // Not sure this is necessary, but sometimes dbCheck results can
              // appear shortly after the command returns ok.
-if (authInfo) {
+if (typeof authInfo !== "undefined") {
   authInfo.db = authInfo.db || 'local';
 }
 checkRollOver();

--- a/replset-consistency/dbcheck.js
+++ b/replset-consistency/dbcheck.js
@@ -227,11 +227,17 @@ function checkRollOver() {
           secondaryCount = Math.min(secondaryCount, tcount);
         }
       } catch (error) {
-        printFunction(error);
+        printFunction({
+          msg: error,
+          _id: nodelist[i]._id,
+          host: nodelist[i].host,
+        });
       }
     }
   } else {
-    printFunction("authInfo object is undefined; performing weak healthlog rollover check.")
+    printFunction({
+      msg: "authInfo object is undefined; performing weak healthlog rollover check.",
+    });
     for (let i = 0; i < ((getWriteConcern() - 1) * 2); i++) {
       try {
         let tcount = getDBCheckCount("secondary");

--- a/replset-consistency/dbcheck.js
+++ b/replset-consistency/dbcheck.js
@@ -154,7 +154,7 @@ function getDBCheckCount(readPref) {
   db.getMongo().setReadPref(readPref);
 
   let curr = db.getSiblingDB("local").system.healthlog.aggregate([
-    {$match : {operation : "dbCheckStart"}}, {$count : "dbCheckStartCount"}
+    {$match : {operation : "dbCheckStart", timestamp : {$gte: new ISODate(timerStart.toISOString())}}}, {$count : "dbCheckStartCount"}
   ]);
   if (curr.hasNext()) {
     let my_count = curr.next().dbCheckStartCount;
@@ -166,7 +166,7 @@ function getDBCheckCount(readPref) {
 function getDBCheckCountByNode(node) {
   let conn = node.connection
   let curr = conn.getDB("local").getCollection("system.healthlog").aggregate([     
-    {$match : {operation : "dbCheckStart"}}, {$count : "dbCheckStartCount"}   
+    {$match : {operation : "dbCheckStart", timestamp : {$gte: new ISODate(timerStart.toISOString())}}}, {$count : "dbCheckStartCount"}   
   ])
   if (curr.hasNext()) {
     let my_count = curr.next().dbCheckStartCount;


### PR DESCRIPTION
This PR contains 2 parts:
1. An authentication implementation taken from scan_checked_replset.js to enable healthlog queries on all secondary nodes
2. A modification to counting dbCheckStart to count only entries that start from when the script is run.

2 fixes a bug where running dbcheck.js multiple times will never return that a healthlog has failed over because the runCount will never be less than the primary and secondary start counts.