### PR TITLE
redact passwords

### DIFF
--- a/mdiag/mdiag.sh
+++ b/mdiag/mdiag.sh
@@ -44,8 +44,8 @@
 # limitations under the License.
 
 
-version="2.0.5"
-revdate="2019-08-26"
+version="2.0.6"
+revdate="2023-01-13"
 
 PATH="$PATH${PATH+:}/usr/sbin:/sbin:/usr/bin:/bin"
 

--- a/mdiag/mdiag.sh
+++ b/mdiag/mdiag.sh
@@ -398,7 +398,7 @@ function getfiles {
 
 			_nextoutput
 			_graboutput
-			cat "$f"
+			cat "$f" | sed 's/\(.*password.*\):\(.*\)/\1: <REDACTED>/i'
 			_ungraboutput
 			output_fieldname="content"
 		else


### PR DESCRIPTION
quick way to remove potential passwords from files where passwords are in yaml format such as

security.ldap.bind.queryPassword: password123 -> security.ldap.bind.queryPassword: \<REDACTED\>