### PR TITLE
mdiag.sh - add netstat -s

### DIFF
--- a/mdiag/mdiag.sh
+++ b/mdiag/mdiag.sh
@@ -170,6 +170,7 @@ function _main {
 	section networks getfiles /etc/networks
 	section rpcinfo runcommand rpcinfo -p
 	section netstat runcommand netstat -anpoe
+	section netstat_stats runcommand netstat -s
 
 	# Network time info
 	section ntp getfiles /etc/ntp.conf


### PR DESCRIPTION
I find useful the stats provided by `netstat -s`, in particular this one that shows when local listening servers are unresponsive:

netstat -s | grep listen

example taken from https://devops-insider.mygraphql.com/zh_CN/latest/kernel/network/socket/listen-queues/ref/tcp-syn-queue-and-accept-queue-overflow-explained.html:


$ netstat -s | grep -i "listen"
    189088 times the listen queue of a socket overflowed
30140232 SYNs to LISTEN sockets dropped


Those stats get zeroed after system restart and do not show the port but I believe that are useful.

