### PR TITLE
Make getMongoData.js compatible with mongosh

### DIFF
--- a/getMongoData/getMongoData.js
+++ b/getMongoData/getMongoData.js
@@ -263,7 +263,7 @@ function printInfo(message, command, section, printCapture, commandParameters) {
 function printServerInfo() {
     section = "server_info";
     printInfo('Shell version',      version, section);
-    printInfo('Shell hostname',     hostname, section);
+    printInfo('Shell hostname',     typeof hostname !== "undefined" ? hostname : function(){return "N/A"}, section);
     printInfo('db',                 function(){return db.getName()}, section);
     printInfo('Server status info', function(){return db.serverStatus()}, section);
     printInfo('Host info',          function(){return db.hostInfo()}, section);
@@ -580,7 +580,7 @@ if (! _printJSON) {
     print("getMongoData.js version " + _version);
     print("================================");
 }
-var _host = hostname();
+var _host = typeof hostname !== "undefined" ? hostname() : "N/A";
 
 try {
     printServerInfo();


### PR DESCRIPTION
* `mongosh` doesn't include the [native method](https://www.mongodb.com/docs/mongodb-shell/reference/methods/#native-methods) `hostname()` anymore
* to make getMongoData.js compatible with mongosh check if hostname() method exists. If not, use "N/A" as hostname of host running mongosh.