### PR TITLE
STAR-4783: Fix validate.js to make it compatible on mongosh2.0+

### DIFF
--- a/replset-consistency/validate.js
+++ b/replset-consistency/validate.js
@@ -106,8 +106,10 @@ var failArray = [];
 var seen = [];
 var partial = false;
 
-// overloads db.getSiblingDB() which overwrites the runCommand
+// Overloads db.getSiblingDB() which overwrites the runCommand
 // to take readPreference into consideration 
+// This is needed since mongosh2.0+ no longer allows db.runCommand() to
+// run on secondaries
 const realGetSiblingDB = db.getSiblingDB.bind(db);
 db.getSiblingDB = (dbName) => {
   const dbToRet = realGetSiblingDB(dbName);

--- a/replset-consistency/validate.js
+++ b/replset-consistency/validate.js
@@ -106,6 +106,21 @@ var failArray = [];
 var seen = [];
 var partial = false;
 
+// overloads db.getSiblingDB() which overwrites the runCommand
+// to take readPreference into consideration 
+const realGetSiblingDB = db.getSiblingDB.bind(db);
+db.getSiblingDB = (dbName) => {
+  const dbToRet = realGetSiblingDB(dbName);
+ 
+  const realRunCommand = dbToRet.runCommand.bind(dbToRet);
+  dbToRet.runCommand = (cmd) => {
+    return realRunCommand(cmd, {
+      readPreference: dbToRet.getMongo().getReadPref().mode,
+    });
+  };
+  return dbToRet;
+};
+
 function validateCollection(d, coll, validateFull) {
     var validate_results = {"valid": false};
     if (partial) {


### PR DESCRIPTION
### Changes:
-  runCommand in mongosh2.0+, does not inherit global read preference. 
- Overloaded db.getSiblingDB() to consider `readPreference` while connecting through mongosh 2.0

### Testing:

Spun a replica-set:
```
noopur.gupta@M-NQJY3C9YVN replset-consistency % lm
  PID TTY           TIME CMD
89777 ??        74:37.46 mongod --replSet shard01 --dbpath /Users/noopur.gupta/MongoDB/jiratickets/server/84628/data/shard01/rs1/db --logpath /Users/noopur.gupta/MongoDB/jiratickets/server/84628/data/shard01/rs1/mongod.log --port 27018 --fork --shardsvr --wiredTigerCacheSizeGB 1
89783 ??        71:33.08 mongod --replSet shard01 --dbpath /Users/noopur.gupta/MongoDB/jiratickets/server/84628/data/shard01/rs2/db --logpath /Users/noopur.gupta/MongoDB/jiratickets/server/84628/data/shard01/rs2/mongod.log --port 27019 --fork --shardsvr --wiredTigerCacheSizeGB 1
89786 ??        75:51.61 mongod --replSet shard01 --dbpath /Users/noopur.gupta/MongoDB/jiratickets/server/84628/data/shard01/rs3/db --logpath /Users/noopur.gupta/MongoDB/jiratickets/server/84628/data/shard01/rs3/mongod.log --port 27020 --fork --shardsvr --wiredTigerCacheSizeGB 1
89789 ??        24:31.66 mongos --logpath /Users/noopur.gupta/MongoDB/jiratickets/server/84628/data/mongos.log --port 27017 --configdb configRepl/localhost:27021 --fork
```
#### Before Fix
`validate.js` fails on secondary with below error:
```
noopur.gupta@M-NQJY3C9YVN replset-consistency % mongosh 127.0.0.1:27018 validate.js
Current Mongosh Log ID:	65a9a6a425700a585c0f4651
Connecting to:		mongodb://127.0.0.1:27018/?directConnection=true&serverSelectionTimeoutMS=2000&appName=mongosh+2.1.1
(node:23755) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
Using MongoDB:		7.0.4
Using Mongosh:		2.1.1

For mongosh info see: https://docs.mongodb.com/mongodb-shell/

------
   The server generated these startup warnings when booting
   2024-01-10T14:26:57.508-08:00: Access control is not enabled for the database. Read and write access to data and configuration is unrestricted
   2024-01-10T14:26:57.508-08:00: This server is bound to localhost. Remote systems will be unable to connect to this server. Start the server with --bind_ip <address> to specify which IP addresses it should serve responses from, or with --bind_ip_all to bind to all interfaces. If this behavior is desired, start the server with --bind_ip 127.0.0.1 to disable this warning
   2024-01-10T14:26:57.508-08:00: Soft rlimits for open file descriptors too low
------

Loading file: validate.js
MongoServerError: not primary and secondaryOk=false - consider using db.getMongo().setReadPref() or readPreference in the connection string
noopur.gupta@M-NQJY3C9YVN replset-consistency %
```
#### After fix:
 Run validate on all 3 nodes:

Primary node:
```
noopur.gupta@M-NQJY3C9YVN replset-consistency % mongosh 127.0.0.1:27020 validate.js
Current Mongosh Log ID:	65a9a82a6fa8a395d2b37e9b
Connecting to:		mongodb://127.0.0.1:27020/?directConnection=true&serverSelectionTimeoutMS=2000&appName=mongosh+2.1.1
.
.
.
{"validation":"passed","valid":true,"full":false,"passing":26,"failing":0,"failingNS":[],"partial":false,"host":"localhost:27020","setName":"shard01","time":{"$date":"2024-01-18T22:37:30.832Z"},"lastStartup":{"$date":"2024-01-10T22:26:58.627Z"},"validateDurationSecs":0.054}
```

Secondary node1:
```
noopur.gupta@M-NQJY3C9YVN replset-consistency % mongosh 127.0.0.1:27018 validate.js
Current Mongosh Log ID:	65a9a77710b503e2860b87c6
Connecting to:		mongodb://127.0.0.1:27018/?directConnection=true&serverSelectionTimeoutMS=2000&appName=mongosh+2.1.1
Using MongoDB:		7.0.4
Using Mongosh:		2.1.1

For mongosh info see: https://docs.mongodb.com/mongodb-shell/

------
   The server generated these startup warnings when booting
   2024-01-10T14:26:57.508-08:00: Access control is not enabled for the database. Read and write access to data and configuration is unrestricted
   2024-01-10T14:26:57.508-08:00: This server is bound to localhost. Remote systems will be unable to connect to this server. Start the server with --bind_ip <address> to specify which IP addresses it should serve responses from, or with --bind_ip_all to bind to all interfaces. If this behavior is desired, start the server with --bind_ip 127.0.0.1 to disable this warning
   2024-01-10T14:26:57.508-08:00: Soft rlimits for open file descriptors too low
------

Loading file: validate.js
.
.
.
{"validation":"passed","valid":true,"full":false,"passing":26,"failing":0,"failingNS":[],"partial":false,"host":"localhost:27018","setName":"shard01","time":{"$date":"2024-01-18T22:34:31.498Z"},"lastStartup":{"$date":"2024-01-10T22:26:56.690Z"},"validateDurationSecs":0.053}
```

Secondary node2:
```
noopur.gupta@M-NQJY3C9YVN replset-consistency % mongosh 127.0.0.1:27019 validate.js
Current Mongosh Log ID:	65a9a7b2341fd27e9109ef17
Connecting to:		mongodb://127.0.0.1:27019/?directConnection=true&serverSelectionTimeoutMS=2000&appName=mongosh+2.1.1
.
.
{"validation":"passed","valid":true,"full":false,"passing":26,"failing":0,"failingNS":[],"partial":false,"host":"localhost:27019","setName":"shard01","time":{"$date":"2024-01-18T22:35:31.023Z"},"lastStartup":{"$date":"2024-01-10T22:26:57.660Z"},"validateDurationSecs":0.055}
```

### Ticket:
https://jira.mongodb.org/browse/STAR-4783