### PR TITLE
Replace getMongoData.js legacy mongo shell script with mongoWellnessChecker.js script for new mongosh shell

### DIFF
--- a/mongoWellnessChecker/README.md
+++ b/mongoWellnessChecker/README.md
@@ -1,0 +1,122 @@
+MongoDB Support Tools
+=====================
+
+mongoWellnessChecker.js
+---------------
+
+### Description
+
+`mongoWellnessChecker.js` is a utility for gathering information about how a running
+MongoDB deployment has been configured and for gathering statistics about its
+databases, collections, indexes, and shards.
+
+For sample output, see [mongoWellnessChecker-output.json](sample/mongoWellnessChecker-output.json).
+
+### Usage
+
+To execute on a locally-running `mongod` or `mongos` on the default port (27017)
+without authentication, run:
+
+    mongosh --quiet --norc mongoWellnessChecker.js > mongoWellnessChecker-output.json
+
+To execute on a remote `mongod` or `mongos` with authentication (see the next
+section for the minimum required permissions), run:
+
+    mongosh HOST:PORT/admin -u ADMIN_USER -p ADMIN_PASSWORD --quiet --norc mongoWellnessChecker.js > mongoWellnessChecker-output.json
+
+If `ADMIN_PASSWORD` is omitted, the shell will prompt for the password.
+
+To have the output be in a more human-readable (non-JSON format), modify the above
+commands to include the following `--eval` option, as demonstrated for the local
+execution:
+
+    mongosh --eval "var _printJSON=false;" mongoWellnessChecker.js > mongoWellnessChecker-output.log
+
+To have a `mongos` for a sharded cluster output full details of chunk
+distribution across shards, include `var _printChunkDetails=true` in the
+`--eval` option:
+
+    mongosh --quiet --norc --eval "var _printChunkDetails=true; var _ref = 'Support Case NNNNN'" mongoWellnessChecker.js > mongoWellnessChecker-output.json
+
+### More Details
+
+`mongoWellnessChecker.js` is JavaScript script which must be run using the `mongosh` shell
+against either a `mongod` or a `mongos`.**Do not run with legacy mongo shell**
+
+Minimum required permissions (see [MongoDB Built-In Roles](https://docs.mongodb.com/manual/reference/built-in-roles)):
+* A database user with the `backup`, `readAnyDatabase`, and `clusterMonitor` roles. These are essentially read-only roles except the [backup](https://docs.mongodb.com/manual/reference/built-in-roles/#backup-and-restoration-roles) role allows writes to two MongoDB system collections - `admin.mms.backup` and `config.settings`. The `backup` role is necessary in order for the script to output the number of database users and user-defined roles configured.
+* A root/admin database user may be used as well.
+
+Example command for creating a database user with the minimum required permissions:
+
+```
+db.getSiblingDB("admin").createUser({
+    user: "ADMIN_USER",
+    pwd: "ADMIN_PASSWORD",
+    roles: [ "backup", "readAnyDatabase", "clusterMonitor" ]
+  })
+```
+
+The most notable methods, commands, and aggregations that this script runs are listed below.
+
+**Server Process Config & Stats**
+* [serverStatus](https://docs.mongodb.com/manual/reference/command/serverStatus)
+* [hostInfo](https://docs.mongodb.com/manual/reference/command/hostInfo)
+* [getCmdLineOpts](https://docs.mongodb.com/manual/reference/command/getCmdLineOpts)
+* [buildInfo](https://docs.mongodb.com/manual/reference/command/buildInfo)
+* [getParameter](https://docs.mongodb.com/manual/reference/command/getParameter/)
+
+**Replica Set Config & Stats**
+* [rs.conf()](https://docs.mongodb.com/manual/reference/method/rs.conf/)
+* [rs.status()](https://docs.mongodb.com/manual/reference/method/rs.status/)
+* [db.getReplicationInfo()](https://docs.mongodb.com/manual/reference/method/db.getReplicationInfo)
+* [db.printSecondaryReplicationInfo()](https://docs.mongodb.com/manual/reference/method/db.printSecondaryReplicationInfo)
+
+**Database Users and User-Defined Roles (the count only)**
+* [db.system.users.count()](https://docs.mongodb.com/manual/reference/system-users-collection/) in the "admin" database
+* [db.system.roles.count()](https://docs.mongodb.com/manual/reference/system-roles-collection/) in the "admin" databases
+
+**Database, Collection, and Index Config & Stats**
+* [listDatabases](https://docs.mongodb.com/manual/reference/command/listDatabases/)
+* [db.getCollectionNames()](https://docs.mongodb.com/manual/reference/method/db.getCollectionNames/)
+* [db.stats()](https://docs.mongodb.com/manual/reference/method/db.stats/)
+* [db.getProfilingStatus()](https://docs.mongodb.com/manual/reference/method/db.getProfilingStatus/)
+* [db.collection.stats()](https://docs.mongodb.com/manual/reference/method/db.collection.stats/)
+* [db.collection.getShardDistribution()](https://docs.mongodb.com/manual/reference/method/db.collection.getShardDistribution/)
+* [db.collection.getIndexes()](https://docs.mongodb.com/manual/reference/method/db.collection.getIndexes/)
+* [$indexStats](https://docs.mongodb.com/manual/reference/operator/aggregation/indexStats/)
+
+**Sharding Config & Stats**
+* Queries and aggregations on various collections in the MongoDB [config database](https://docs.mongodb.com/manual/reference/config-database/), including the "version", "settings", "routers", "shards", "databases", "chunks", and "tags" collections.
+
+**Queryable Encryption (QE) Config**
+* [db.getCollectionInfos()](https://docs.mongodb.com/manual/reference/method/db.getCollectionInfos/)
+* Performs queries and aggregations on QE collections and auxiliary collections in all databases. The output is an
+array of objects, each containing information about a queryable encrypted collection.
+
+### Additional Notes
+* This script should take on the order of seconds to run.
+* If your deployment has more than 2500 collections, this script will by default fail.
+
+### License
+
+[Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0)
+
+
+DISCLAIMER
+----------
+Please note: all tools/ scripts in this repo are released for use "AS IS" **without any warranties of any kind**,
+including, but not limited to their installation, use, or performance.  We disclaim any and all warranties, either
+express or implied, including but not limited to any warranty of noninfringement, merchantability, and/ or fitness
+for a particular purpose.  We do not warrant that the technology will meet your requirements, that the operation
+thereof will be uninterrupted or error-free, or that any errors will be corrected.
+
+Any use of these scripts and tools is **at your own risk**.  There is no guarantee that they have been through
+thorough testing in a comparable environment and we are not responsible for any damage or data loss incurred with
+their use.
+
+You are responsible for reviewing and testing any scripts you run *thoroughly* before use in any non-testing
+environment.
+
+Thanks,
+The MongoDB Support Team

--- a/mongoWellnessChecker/README.md
+++ b/mongoWellnessChecker/README.md
@@ -19,10 +19,10 @@ without authentication, run:
 
     mongosh --quiet --norc mongoWellnessChecker.js > mongoWellnessChecker-output.json
 
-To execute on a remote `mongod` or `mongos` with authentication (see the next
+To execute on a remote `mongod` or `mongos` with authentication and SSL/TLS (see the next
 section for the minimum required permissions), run:
 
-    mongosh HOST:PORT/admin -u ADMIN_USER -p ADMIN_PASSWORD --quiet --norc mongoWellnessChecker.js > mongoWellnessChecker-output.json
+    mongosh HOST:PORT/admin -u ADMIN_USER -p ADMIN_PASSWORD --quiet --norc --tls mongoWellnessChecker.js > mongoWellnessChecker-output.json
 
 If `ADMIN_PASSWORD` is omitted, the shell will prompt for the password.
 
@@ -31,12 +31,6 @@ commands to include the following `--eval` option, as demonstrated for the local
 execution:
 
     mongosh --eval "var _printJSON=false;" mongoWellnessChecker.js > mongoWellnessChecker-output.log
-
-To have a `mongos` for a sharded cluster output full details of chunk
-distribution across shards, include `var _printChunkDetails=true` in the
-`--eval` option:
-
-    mongosh --quiet --norc --eval "var _printChunkDetails=true; var _ref = 'Support Case NNNNN'" mongoWellnessChecker.js > mongoWellnessChecker-output.json
 
 ### More Details
 

--- a/mongoWellnessChecker/mongoWellnessChecker.js
+++ b/mongoWellnessChecker/mongoWellnessChecker.js
@@ -1,0 +1,592 @@
+/* global db, tojson, tojsononeline, rs, print, printjson */
+
+/* =================================================
+ * mongoWellnessChecker.js: MongoDB Config and Schema Report using mongosh
+ * =================================================
+ *
+ * Copyright MongoDB, Inc, 2023
+ *
+ * Gather MongoDB configuration and schema information with mongosh shell. 
+ *
+ * WARNING: DO NOT USE Legacy mongo shell with this script. 
+ *
+ * To execute on a locally running mongod on default port (27017) without
+ * authentication, run:
+ *
+ *     mongosh getMongoWellnessChecker.js > getMongoWellnessChecker.log
+ *
+ * To execute on a remote mongod or mongos with authentication, run:
+ *
+ *     mongosh HOST:PORT/admin -u ADMIN_USER -p ADMIN_PASSWORD getMongoWellnessChecker.js > getMongoWellnessChecker.log
+ *
+ *
+ * DISCLAIMER
+ *
+ * Please note: all tools/ scripts in this repo are released for use "AS
+ * IS" without any warranties of any kind, including, but not limited to
+ * their installation, use, or performance. We disclaim any and all
+ * warranties, either express or implied, including but not limited to
+ * any warranty of noninfringement, merchantability, and/ or fitness for
+ * a particular purpose. We do not warrant that the technology will
+ * meet your requirements, that the operation thereof will be
+ * uninterrupted or error-free, or that any errors will be corrected.
+ *
+ * Any use of these scripts and tools is at your own risk. There is no
+ * guarantee that they have been through thorough testing in a
+ * comparable environment and we are not responsible for any damage
+ * or data loss incurred with their use.
+ *
+ * You are responsible for reviewing and testing any scripts you run
+ * thoroughly before use in any non-testing environment.
+ *
+ *
+ * LICENSE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+//Make the ObjectID format in the output same as the legacy getMongoData script
+if (typeof (ObjectId) != "undefined") {
+
+	ObjectId.prototype.toJSON = ObjectId.prototype.toExtendedJSON;
+}
+
+//Make the Timestamp format in the output same as the legacy getMongoData script
+if (typeof (Timestamp) != "undefined") {
+
+
+    Timestamp.prototype.toJSON = function() {
+        return this.toStringIncomparable(); 
+     };
+
+    Timestamp.prototype.toStringIncomparable = function() {
+        var t = this.hasOwnProperty("t") ? this.t : this.high;
+        var i = this.hasOwnProperty("i") ? this.i : this.low;
+	var timestamplegacy = {};
+        var tsdoc = {} ;
+        tsdoc['t'] = t;
+        tsdoc['i'] = i;
+	timestamplegacy['$timestamp']=tsdoc;
+        return timestamplegacy;
+
+    };
+} else {
+    print("warning: no Timestamp class");
+}
+
+// Taken from legacy getMongoData.js script and then modified it to work with mongosh 
+if (typeof print.captureAllOutput === "undefined") {
+    print.captureAllOutput = function (fn, args) {
+        var res = {};
+        res.output = [];
+        var __orig_print = print;
+        print = function () { 
+		Array.prototype.push.apply(res.output, Array.prototype.slice.call(arguments).join(" ").split("\n")); 
+	};
+        try { 
+            res.result = fn.apply(undefined, args);
+        } catch(e) { 
+		print(e);
+	}
+        finally {
+            // Stop capturing print() output
+            print = __orig_print;
+        }
+        return res;
+    };
+}
+
+// For use in JSON.stringify to properly serialize known types
+function jsonStringifyReplacer(k, v){
+    //if (v instanceof ObjectId)
+    //    return { "$oid" : v.toString() };
+    if (v instanceof Long)
+        return { "$numberLong" : longmangle(v) };
+    if (v instanceof Int32)
+        return v.toNumber();
+    // For ISODates; the $ check prevents recursion
+    if (typeof v === "string" && k.startsWith('$') == false){
+        try {
+            iso = ISODate(v);
+            return { "$date" : iso.valueOf() };
+        }
+        // Nothing to do here, we'll get the return at the end
+        catch(e) {}
+    }
+    return v;
+}
+
+
+//As of mongosh 1.8.0 Long and NumberLong appear to be used interchangeably
+function longmangle(n) {
+    if (!(n instanceof NumberLong || n instanceof Long))
+        return null;
+    var s = n.toString();
+    return s;
+}
+
+function printInfo(message, command, section="notdefined", printCapture=false, commandParameters={}) {
+
+	//validation checks
+	//message is mandatory arg
+	try {
+
+		if (typeof message !== 'string') {
+			throw("printInfo message argument is not a string");
+		} 
+		//command is mandatory arg
+		if (typeof command !== 'function') {
+			throw("printInfo command argument is not a function");
+		}
+		err=null;
+	} catch(err) {
+		throw("printInfo error handing message or command: " + err);
+	}
+
+	const testFunction = function () { return false; };
+	const allowedCommandFunctionNames = [testFunction.name,"printServerInfoShellVersion","printServerInfoShellHostname","printServerInfoCurrentDBname","printServerInfoCurrentDBname","printServerInfoServerStatus","printServerInfoHostInfo","printServerInfoCmdLineInfo","printServerInfoServerBuildInfo","printServerInfoServerParams","printReplicaSetInfoRSConfig","printReplicaSetInfoRSStatus","printReplicaSetInfoGetReplicationInfo","printReplicaSetInfoPrintSecondaryReplicationInfo","printShardOrReplicaSetInfoIsMaster","printUserAuthInfoDBUserCount","printUserAuthInfoCustomRoleCount","printShardInfoGetShardingVersion","printShardInfoGetShardingSettings","printShardInfoGetMongoses","printShardInfoGetShards","printShardInfoGetShardedDatabases","printShardInfoGetBalancerStatus","printDataInfoListDatabases","printDataInfoListCollectionsForDatabases","printDataInfoDBStats","printDataInfoGetProfilingStatusForDB","printDataInfoGetCollStats","printDataInfoListIndexesForColl","printDataInfoIndexStats","printDataInfoShardDistribution"];
+
+	if (!allowedCommandFunctionNames.includes(command.name)) {
+		throw("printInfo Not in the approved list of functions: " + command.name);
+	}
+
+	var result = false; 
+
+	//printCapture default value of false of type boolean is declared in the function signature
+	//if printCapture is defined it must be boolean
+	if (typeof printCapture !== 'boolean') {
+		throw("printInfo printCapture argument is not a boolean");
+	} 
+
+	if (! _printJSON) print("\n** " + message + ":");
+	startTime = new Date();
+	try {
+
+		if (printCapture) { 
+
+			result = print.captureAllOutput(command);
+		} else {
+
+			result = command();
+		}
+		err = null;
+	} catch(err) {
+		if (! _printJSON) {
+			print("printInfo Error running '" + command + "':");
+			print(err);
+		} else {
+			throw("printInfo Error running '" + command + "': " + err);
+		}
+	}
+
+
+	endTime = new Date();
+	doc = {};
+	doc['command'] = command.toString();
+	doc['error'] = err;
+	doc['host'] = _host;
+	doc['ref'] = _ref;
+	doc['tag'] = _tag;
+	doc['output'] = result;
+
+	try { 
+
+
+		//section parameter default value set to "notdefined" string which is not used in any other calls to printInfo
+		if (section !== "notdefined") { 
+			doc['section'] = section; 
+			doc['subsection'] = message.toLowerCase().replace(/ /g, "_"); 
+		} else { 
+			doc['section'] = message.toLowerCase().replace(/ /g, "_"); 
+		}
+		err = null;
+	} catch(err) {
+		throw("printInfo Error handling section parameter: " + err);
+	}
+
+	doc['ts'] = {'start': startTime, 'end': endTime};
+	doc['version'] = _version;
+
+	try { 
+
+
+		//commandParameters parameter default value set to {} 
+		if (commandParameters !== {} ) { doc['commandParameters'] = commandParameters; }
+	} catch(err) {
+		throw("printInfo Error handling commandParameters");
+	}
+	_output.push(doc);
+	if (! _printJSON) printjson(result);
+	return result;
+}
+
+// This function has been included as is from the legacy getMongoData.js script 
+function printShardInfo(){
+
+	const printShardInfoGetShardingVersion = function(){return configDB.getCollection('version').findOne();}; 
+	const printShardInfoGetShardingSettings = function(){return configDB.settings.find().sort({ _id : 1 }).toArray();}; 
+	const printShardInfoGetMongoses = function(){return configDB.mongos.find().sort({ _id : 1 }).toArray();}; 
+	const printShardInfoGetShards = function(){return configDB.shards.find().sort({ _id : 1 }).toArray();}; 
+	//legacy Regex.escape() replacement
+	const escapeRegex = function(text){return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");};
+	const printShardInfoGetShardedDatabases = function(){
+        var ret = [];
+        configDB.databases.find().sort( { name : 1 } ).forEach(
+            function(db) {
+                doc = {};
+                for (k in db) {
+                    if (db.hasOwnProperty(k)) doc[k] = db[k];
+                }
+                if (db.partitioned) {
+                    doc['collections'] = [];
+                    configDB.collections.find( { _id : new RegExp( "^" +
+                        escapeRegex(db._id) + "\\." ) } ).
+                        sort( { _id : 1 } ).forEach( function( coll ) {
+                            if ( coll.dropped !== true ){
+                                collDoc = {};
+                                collDoc['_id'] = coll._id;
+                                collDoc['key'] = coll.key;
+                                collDoc['unique'] = coll.unique;
+
+                                var res = configDB.chunks.aggregate(
+                                    { "$match": { ns: coll._id } },
+                                    { "$group": { _id: "$shard", nChunks: { "$sum": 1 } } }
+                                );
+                                // MongoDB 2.6 and above returns a cursor instead of a document
+                                res = (res.result ? res.result : res.toArray());
+
+                                collDoc['distribution'] = [];
+                                res.forEach( function(z) {
+                                    chunkDistDoc = {'shard': z._id, 'nChunks': z.nChunks};
+                                    collDoc['distribution'].push(chunkDistDoc);
+                                } );
+
+				if (_printChunkDetails) {
+                                    collDoc['chunks'] = [];
+                                    configDB.chunks.find( { "ns" : coll._id } ).sort( { min : 1 } ).forEach(
+					function(chunk) {
+                                            chunkDoc = {}
+                                            chunkDoc['min'] = chunk.min;
+                                            chunkDoc['max'] = chunk.max;
+                                            chunkDoc['shard'] = chunk.shard;
+                                            chunkDoc['jumbo'] = chunk.jumbo ? true : false;
+                                            collDoc['chunks'].push(chunkDoc);
+					}
+                                    );
+				}
+
+                                collDoc['tags'] = [];
+                                configDB.tags.find( { ns : coll._id } ).sort( { min : 1 } ).forEach(
+                                    function(tag) {
+                                        tagDoc = {}
+                                        tagDoc['tag'] = tag.tag;
+                                        tagDoc['min'] = tag.min;
+                                        tagDoc['max'] = tag.max;
+                                        collDoc['tags'].push(tagDoc);
+                                    }
+                                );
+			        doc['collections'].push(collDoc);
+                            }
+                        }
+                    );
+                }
+                ret.push(doc);
+            }
+        );
+        return ret;
+    }; 
+	const printShardInfoGetBalancerStatus = function(){return db.adminCommand({balancerStatus: 1});}; 
+	const printShardInfoGetRecentMigrations = function(){return sh.getRecentMigrations();}; 
+	const printShardInfoGetRecentFailedBalancerRounds = function(){return sh.getRecentFailedRounds();}; 
+
+	section = "shard_info"; 
+	var configDB = db.getSiblingDB("config"); 
+	
+	printInfo("Sharding version", printShardInfoGetShardingVersion, section); 
+	printInfo("Sharding settings", printShardInfoGetShardingSettings, section); 
+	printInfo("Routers", printShardInfoGetMongoses, section); 
+	printInfo("Shards", printShardInfoGetShards, section); 
+	printInfo("Sharded databases", printShardInfoGetShardedDatabases, section); 
+	printInfo('Balancer status', printShardInfoGetBalancerStatus, section); 
+	
+	if (sh.getRecentMigrations) { 
+		// Function does not exist in older shell versions (2.6 and below) 
+		printInfo('Recent chunk migrations', printShardInfoGetRecentMigrations, section); 
+	} else { 
+		if (! _printJSON) print("\n** Recent chunk migrations: n/a") 
+	} 
+	
+	if (sh.getRecentFailedRounds) { 
+		// Function does not exist in older shell versions (2.6 and below) 
+		printInfo('Recent failed balancer rounds', printShardInfoGetRecentFailedBalancerRounds, section); 
+	} else { 
+		if (! _printJSON) print("\n** Recent failed balancer rounds: n/a") 
+	}
+}
+
+function printDataInfo(isMongoS) {
+
+
+	section = "data_info"; 
+
+	const printDataInfoListDatabases = function(){return db.getMongo().getDBs();}; 
+
+
+	var dbs = printInfo('List of databases', printDataInfoListDatabases, section); 
+	var collections_counter = 0; 
+
+	if (dbs.databases) { 
+		dbs.databases.forEach(function(mydb) {
+
+
+
+
+				//the functions that access variables in scope of the parent function need to be defined locally 
+				const printDataInfoListCollectionsForDatabases =  function(){ 
+				var collectionNames = [] 
+				// Filter out views 
+				db.getSiblingDB(mydb.name).getCollectionInfos({"type": "collection"}).forEach(function(collectionInfo) { 
+						collectionNames.push(collectionInfo['name']); 
+						}); 
+
+				// Filter out the collections with the "system." prefix in the system databases 
+				if (mydb.name == "config" || mydb.name == "local" || mydb.name == "admin") { 
+				return collectionNames.filter(function (str) { return str.indexOf("system.") != 0; })
+				.filter(function(str) { return str.indexOf("replset.") != 0; }); 
+				} else { return collectionNames; } }; 
+
+				var collections = printInfo("List of collections for database '"+ mydb.name +"'", printDataInfoListCollectionsForDatabases, section); 
+
+
+				const printDataInfoDBStats = function(){return db.getSiblingDB(mydb.name).stats(1024*1024);}; 
+				printInfo('Database stats (MB)', printDataInfoDBStats, section); 
+
+
+				const printDataInfoGetProfilingStatusForDB = function(){return db.getSiblingDB(mydb.name).getProfilingStatus();}; 
+				if (!isMongoS) { printInfo("Database profiler for database '"+ mydb.name + "'", printDataInfoGetProfilingStatusForDB, section, false, {"db": mydb.name}) }
+
+				if (collections) {
+
+
+					collections.forEach(function(col) { 
+
+
+							const printDataInfoGetCollStats = function(){return db.getSiblingDB(mydb.name).getCollection(col).stats(1024*1024);}; 
+							printInfo('Collection stats (MB)',printDataInfoGetCollStats, section); 
+
+							collections_counter++; 
+
+							if (collections_counter > _maxCollections) { 
+							var err_msg = 'Already asked for stats on '+collections_counter+' collections ' + 
+							'which is above the max allowed for this script. No more database and ' + 
+							'collection-level stats will be gathered, so the overall data is ' + 
+							'incomplete. ' 
+							if (_printJSON) { 
+							err_msg += 'The "subsection" fields have been prefixed with "INCOMPLETE_" ' + 
+							'to indicate that partial data has been outputted.' } 
+							throw { name: 'MaxCollectionsExceededException', message: err_msg } 
+							} 
+
+							const printDataInfoShardDistribution = function(){return db.getSiblingDB(mydb.name).getCollection(col).getShardDistribution();}; 
+							if (isMongoS) { printInfo('Shard distribution', printDataInfoShardDistribution, section, true); } 
+
+
+							const printDataInfoListIndexesForColl = function(){return db.getSiblingDB(mydb.name).getCollection(col).getIndexes();}; 
+							printInfo('Indexes', printDataInfoListIndexesForColl, section, false, {"db": mydb.name, "collection": col}); 
+
+
+							const printDataInfoIndexStats = function(){
+								try {
+									var res = db.getSiblingDB(mydb.name).runCommand( {
+aggregate: col,
+pipeline: [
+{$indexStats: {}},
+{$group: {_id: "$key", stats: {$push: {accesses: "$accesses.ops", host: "$host", since: "$accesses.since"}}}},
+{$project: {key: "$_id", stats: 1, _id: 0}}
+],
+cursor: {}
+});
+err=null;
+}catch(err) {
+	return "Error running index stats on Database " + mydb.name + " Collection " + col + " Error: " + err;
+}
+
+//It is assumed that there always will be a single batch as collections
+//are limited to 64 indexes and usage from all shards is grouped
+//into a single document
+try {
+	if (res.hasOwnProperty('cursor') && res.cursor.hasOwnProperty('firstBatch')) {
+		res.cursor.firstBatch.forEach(
+				function(d){
+				d.stats.forEach(
+						function(d){
+						d.since = d.since.toUTCString();
+						})
+				});
+	} 
+	err=null;
+} catch(err) {
+	return "Error running index stats on Database " + mydb.name + " Collection " + col + " res processing Error: " + err;
+}
+
+return res;
+};
+
+printInfo('Index Stats', printDataInfoIndexStats, section);
+});
+}
+});
+}
+}
+
+function printReplicaSetInfo() {
+	const printReplicaSetInfoRSConfig = function(){return rs.conf();};
+	const printReplicaSetInfoRSStatus = function(){return rs.status();};
+	const printReplicaSetInfoGetReplicationInfo = function(){return db.getReplicationInfo();};
+	const printReplicaSetInfoPrintSecondaryReplicationInfo = function(){return db.printSecondaryReplicationInfo();}; 
+	
+	section = "replicaset_info"; 
+	printInfo('Replica set config', printReplicaSetInfoRSConfig, section); 
+	printInfo('Replica status', printReplicaSetInfoRSStatus, section); 
+	printInfo('Replica info', printReplicaSetInfoGetReplicationInfo, section); 
+	printInfo('Replica slave info', printReplicaSetInfoPrintSecondaryReplicationInfo, section, true);
+}
+
+function printServerInfo() {
+	const printServerInfoShellVersion = function() { return version(); };
+	const printServerInfoShellHostname = function() { /**mongosh way*/ return os.hostname();}; 
+	const printServerInfoCurrentDBname = function() { return db.getName();};
+	const printServerInfoServerStatus = function() { return db.serverStatus();};
+	const printServerInfoHostInfo = function(){return db.hostInfo();};
+	const printServerInfoCmdLineInfo = function(){return db.serverCmdLineOpts();};
+	const printServerInfoServerBuildInfo = function(){return db.serverBuildInfo();};
+	const printServerInfoServerParams = function(){return db.adminCommand({getParameter: '*'});}; 
+
+	section = "server_info"; 
+	printInfo('Shell version', printServerInfoShellVersion, section); 
+	printInfo('Shell hostname', printServerInfoShellHostname, section); 
+	printInfo('db', printServerInfoCurrentDBname, section); 
+	printInfo('Server status info', printServerInfoServerStatus, section); 
+	printInfo('Host info', printServerInfoHostInfo, section); 
+	printInfo('Command line info',  printServerInfoCmdLineInfo, section); 
+	printInfo('Server build info',  printServerInfoServerBuildInfo, section); 
+	printInfo('Server parameters',  printServerInfoServerParams, section);
+}
+
+
+function printShardOrReplicaSetInfo() {
+
+	const printShardOrReplicaSetInfoIsMaster = function(){return db.isMaster();}; 
+	section = "shard_or_replicaset_info"; 
+	printInfo('isMaster', printShardOrReplicaSetInfoIsMaster, section); 
+
+	var state; 
+	var stateInfo; 
+
+	try { 
+		stateInfo = rs.status(); 
+		stateInfo.members.forEach( function( member ) { if ( member.self ) { state = member.stateStr; } } ); 
+		if ( !state ) state = stateInfo.myState; 
+	} 
+	catch(e) { 
+		if(e.info === 'mongos'){state="mongos";} 
+		else if(e.codeName === 'NoReplicationEnabled'){state="standalone";}
+		else {console.log("Unexpected error don't know what to do: "+ e);}
+	}
+
+	if (! _printJSON) print("\n** Connected to " + state); 
+	if (state == "mongos") { 
+		printShardInfo(); 
+		return true; 
+	} else if (state != "standalone") { 
+		if (state == "SECONDARY" || state == 2) { 
+			db.getMongo().setReadPref('secondary');
+		} 
+		printReplicaSetInfo(); 
+	} 
+	return false; 
+}
+
+function printUserAuthInfo() { 
+	section = "user_auth_info"; 
+	db = db.getSiblingDB('admin');
+	const printUserAuthInfoDBUserCount = function(){return db.system.users.countDocuments();};
+	const printUserAuthInfoCustomRoleCount = function(){return db.system.roles.countDocuments();}; 
+	
+	printInfo('Database user count', printUserAuthInfoDBUserCount, section); 
+	printInfo('Custom role count', printUserAuthInfoCustomRoleCount, section);
+}
+
+
+var _version = "1.0.0";
+
+
+(function () {
+   "use strict";
+}());
+
+function updateDataInfoAsIncomplete(isMongoS) {
+  for (i = 0; i < _output.length; i++) {
+    if(_output[i].section != "data_info") { continue; }
+    _output[i].subsection = "INCOMPLETE_"+ _output[i].subsection;
+  }
+}
+
+
+if (typeof _printJSON === "undefined") var _printJSON = true;
+if (typeof _printChunkDetails === "undefined") var _printChunkDetails = false;
+if (typeof _ref === "undefined") var _ref = null;
+
+// Limit the number of collections this script gathers stats on in order
+// to avoid the possibility of running out of file descriptors. This has
+// been set to an extremely conservative number but can be overridden
+// by setting _maxCollections to a higher number prior to running this
+// script.
+if (typeof _maxCollections === "undefined") var _maxCollections = 2500;
+
+var _total_collection_ct = 0;
+var _output = [];
+var _tag = ObjectId();
+if (! _printJSON) {
+    print("================================");
+    print("MongoDB Config and Schema Report");
+    print("getMongoData.js version " + _version);
+    print("================================");
+}
+var _host = db.hostInfo().system.hostname;
+
+try { 
+
+	printServerInfo(); 
+	var isMongoS = printShardOrReplicaSetInfo(); 
+	printUserAuthInfo(); 
+	printDataInfo(isMongoS);
+} catch(e) {
+    // To ensure that the operator knows there was an error, print the error
+    // even when outputting JSON to make it invalid JSON.
+    print('\nERROR: '+e.message);
+
+    if (e.name === 'MaxCollectionsExceededException') {
+      // Prefix the "subsection" fields with "INCOMPLETE_" to make
+      // it clear that the database and collection info are likely to be
+      // incomplete.
+      updateDataInfoAsIncomplete(isMongoS);
+    } else {
+      quit(1);
+   }
+}
+
+// Print JSON output 
+
+if (_printJSON) print(JSON.stringify(_output, jsonStringifyReplacer, 4));

--- a/mongoWellnessChecker/mongoWellnessChecker.js
+++ b/mongoWellnessChecker/mongoWellnessChecker.js
@@ -1,4 +1,4 @@
-/* global db, tojson, tojsononeline, rs, print, printjson */
+/* global db, rs, print, printjson */
 
 /* =================================================
  * mongoWellnessChecker.js: MongoDB Config and Schema Report using mongosh

--- a/mongoWellnessChecker/mongoWellnessChecker.js
+++ b/mongoWellnessChecker/mongoWellnessChecker.js
@@ -20,6 +20,7 @@
  *     mongosh HOST:PORT/admin -u ADMIN_USER -p ADMIN_PASSWORD getMongoWellnessChecker.js > getMongoWellnessChecker.log
  *
  *
+ *
  * DISCLAIMER
  *
  * Please note: all tools/ scripts in this repo are released for use "AS
@@ -143,22 +144,22 @@ function printInfo(message, command, section="notdefined", printCapture=false, c
 	try {
 
 		if (typeof message !== 'string') {
-			throw("printInfo message argument is not a string");
+			throw new Error("printInfo message argument is not a string");
 		} 
 		//command is mandatory arg
 		if (typeof command !== 'function') {
-			throw("printInfo command argument is not a function");
+			throw new Error("printInfo command argument is not a function");
 		}
 		err=null;
 	} catch(err) {
-		throw("printInfo error handing message or command: " + err);
+		throw new Error("printInfo error handing message or command: " + err);
 	}
 
 	const testFunction = function () { return false; };
 	const allowedCommandFunctionNames = [testFunction.name,"printServerInfoShellVersion","printServerInfoShellHostname","printServerInfoCurrentDBname","printServerInfoCurrentDBname","printServerInfoServerStatus","printServerInfoHostInfo","printServerInfoCmdLineInfo","printServerInfoServerBuildInfo","printServerInfoServerParams","printReplicaSetInfoRSConfig","printReplicaSetInfoRSStatus","printReplicaSetInfoGetReplicationInfo","printReplicaSetInfoPrintSecondaryReplicationInfo","printShardOrReplicaSetInfoIsMaster","printUserAuthInfoDBUserCount","printUserAuthInfoCustomRoleCount","printShardInfoGetShardingVersion","printShardInfoGetShardingSettings","printShardInfoGetMongoses","printShardInfoGetShards","printShardInfoGetShardedDatabases","printShardInfoGetBalancerStatus","printDataInfoListDatabases","printDataInfoListCollectionsForDatabases","printDataInfoDBStats","printDataInfoGetProfilingStatusForDB","printDataInfoGetCollStats","printDataInfoListIndexesForColl","printDataInfoIndexStats","printDataInfoShardDistribution"];
 
 	if (!allowedCommandFunctionNames.includes(command.name)) {
-		throw("printInfo Not in the approved list of functions: " + command.name);
+		throw new Error("printInfo Not in the approved list of functions: " + command.name);
 	}
 
 	var result = false; 
@@ -166,7 +167,7 @@ function printInfo(message, command, section="notdefined", printCapture=false, c
 	//printCapture default value of false of type boolean is declared in the function signature
 	//if printCapture is defined it must be boolean
 	if (typeof printCapture !== 'boolean') {
-		throw("printInfo printCapture argument is not a boolean");
+		throw new Error("printInfo printCapture argument is not a boolean");
 	} 
 
 	if (! _printJSON) print("\n** " + message + ":");
@@ -186,7 +187,7 @@ function printInfo(message, command, section="notdefined", printCapture=false, c
 			print("printInfo Error running '" + command + "':");
 			print(err);
 		} else {
-			throw("printInfo Error running '" + command + "': " + err);
+			throw new Error("printInfo Error running '" + command + "': " + err);
 		}
 	}
 
@@ -212,7 +213,7 @@ function printInfo(message, command, section="notdefined", printCapture=false, c
 		}
 		err = null;
 	} catch(err) {
-		throw("printInfo Error handling section parameter: " + err);
+		throw new Error("printInfo Error handling section parameter: " + err);
 	}
 
 	doc['ts'] = {'start': startTime, 'end': endTime};
@@ -224,7 +225,7 @@ function printInfo(message, command, section="notdefined", printCapture=false, c
 		//commandParameters parameter default value set to {} 
 		if (commandParameters !== {} ) { doc['commandParameters'] = commandParameters; }
 	} catch(err) {
-		throw("printInfo Error handling commandParameters");
+		throw new Error("printInfo Error handling commandParameters");
 	}
 	_output.push(doc);
 	if (! _printJSON) printjson(result);
@@ -564,7 +565,12 @@ if (! _printJSON) {
     print("getMongoData.js version " + _version);
     print("================================");
 }
-var _host = db.hostInfo().system.hostname;
+
+try {
+  var _host = db.hostInfo().system.hostname;
+} catch(e) {
+  throw new Error(`Unable to set _host global variable ${e}`);
+}
 
 try { 
 

--- a/mongoWellnessChecker/sample/mongoWellnessChecker-output.json
+++ b/mongoWellnessChecker/sample/mongoWellnessChecker-output.json
@@ -1,0 +1,12041 @@
+[
+    {
+        "command": "function() { return version(); }",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": "1.10.3",
+        "section": "server_info",
+        "subsection": "shell_version",
+        "ts": {
+            "start": {
+                "$date": 1692958188088
+            },
+            "end": {
+                "$date": 1692958188088
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function() { /**mongosh way*/ return os.hostname();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": "M-XXN9KC6KJ6",
+        "section": "server_info",
+        "subsection": "shell_hostname",
+        "ts": {
+            "start": {
+                "$date": 1692958188088
+            },
+            "end": {
+                "$date": 1692958188088
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function() { return db.getName();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": "test",
+        "section": "server_info",
+        "subsection": "db",
+        "ts": {
+            "start": {
+                "$date": 1692958188088
+            },
+            "end": {
+                "$date": 1692958188088
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function() { return db.serverStatus();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+            "version": "6.0.9",
+            "process": "mongod",
+            "pid": {
+                "$numberLong": "3850"
+            },
+            "uptime": 1860,
+            "uptimeMillis": {
+                "$numberLong": "1859818"
+            },
+            "uptimeEstimate": {
+                "$numberLong": "1859"
+            },
+            "localTime": {
+                "$date": 1692958188433
+            },
+            "activeIndexBuilds": {
+                "total": 0,
+                "phases": {
+                    "scanCollection": 0,
+                    "drainSideWritesTable": 0,
+                    "drainSideWritesTablePreCommit": 0,
+                    "waitForCommitQuorum": 0,
+                    "drainSideWritesTableOnCommit": 0,
+                    "processConstraintsViolatonTableOnCommit": 0,
+                    "commit": 0
+                }
+            },
+            "asserts": {
+                "regular": 0,
+                "warning": 0,
+                "msg": 0,
+                "user": 2188,
+                "tripwire": 0,
+                "rollovers": 0
+            },
+            "batchedDeletes": {
+                "batches": 0,
+                "docs": 0,
+                "stagedSizeBytes": 0,
+                "timeMillis": {
+                    "$numberLong": "0"
+                }
+            },
+            "catalogStats": {
+                "collections": 0,
+                "capped": 0,
+                "clustered": 0,
+                "timeseries": 0,
+                "views": 0,
+                "internalCollections": 22,
+                "internalViews": 1
+            },
+            "connections": {
+                "current": 50,
+                "available": 1450,
+                "totalCreated": 631,
+                "active": 15,
+                "threaded": 50,
+                "limitExempt": 46,
+                "exhaustIsMaster": 0,
+                "exhaustHello": 11,
+                "awaitingTopologyChanges": 12
+            },
+            "defaultRWConcern": {
+                "defaultReadConcern": {
+                    "level": "local"
+                },
+                "defaultWriteConcern": {
+                    "w": "majority",
+                    "wtimeout": 0
+                },
+                "defaultWriteConcernSource": "implicit",
+                "defaultReadConcernSource": "implicit",
+                "localUpdateWallClockTime": {
+                    "$date": 1692958181709
+                }
+            },
+            "electionMetrics": {
+                "stepUpCmd": {
+                    "called": {
+                        "$numberLong": "0"
+                    },
+                    "successful": {
+                        "$numberLong": "0"
+                    }
+                },
+                "priorityTakeover": {
+                    "called": {
+                        "$numberLong": "1"
+                    },
+                    "successful": {
+                        "$numberLong": "1"
+                    }
+                },
+                "catchUpTakeover": {
+                    "called": {
+                        "$numberLong": "0"
+                    },
+                    "successful": {
+                        "$numberLong": "0"
+                    }
+                },
+                "electionTimeout": {
+                    "called": {
+                        "$numberLong": "0"
+                    },
+                    "successful": {
+                        "$numberLong": "0"
+                    }
+                },
+                "freezeTimeout": {
+                    "called": {
+                        "$numberLong": "0"
+                    },
+                    "successful": {
+                        "$numberLong": "0"
+                    }
+                },
+                "numStepDownsCausedByHigherTerm": {
+                    "$numberLong": "0"
+                },
+                "numCatchUps": {
+                    "$numberLong": "0"
+                },
+                "numCatchUpsSucceeded": {
+                    "$numberLong": "0"
+                },
+                "numCatchUpsAlreadyCaughtUp": {
+                    "$numberLong": "1"
+                },
+                "numCatchUpsSkipped": {
+                    "$numberLong": "0"
+                },
+                "numCatchUpsTimedOut": {
+                    "$numberLong": "0"
+                },
+                "numCatchUpsFailedWithError": {
+                    "$numberLong": "0"
+                },
+                "numCatchUpsFailedWithNewTerm": {
+                    "$numberLong": "0"
+                },
+                "numCatchUpsFailedWithReplSetAbortPrimaryCatchUpCmd": {
+                    "$numberLong": "0"
+                },
+                "averageCatchUpOps": 0
+            },
+            "encryptionAtRest": {
+                "encryptionEnabled": false
+            },
+            "extra_info": {
+                "note": "fields vary by platform",
+                "user_time_us": {
+                    "$numberLong": "33148840"
+                },
+                "system_time_us": {
+                    "$numberLong": "4225571"
+                },
+                "maximum_resident_set_kb": {
+                    "$numberLong": "209532"
+                },
+                "input_blocks": {
+                    "$numberLong": "60"
+                },
+                "output_blocks": {
+                    "$numberLong": "36496"
+                },
+                "page_reclaims": {
+                    "$numberLong": "24774"
+                },
+                "page_faults": {
+                    "$numberLong": "0"
+                },
+                "voluntary_context_switches": {
+                    "$numberLong": "197061"
+                },
+                "involuntary_context_switches": {
+                    "$numberLong": "14193"
+                }
+            },
+            "flowControl": {
+                "enabled": true,
+                "targetRateLimit": 1000000000,
+                "timeAcquiringMicros": {
+                    "$numberLong": "1118"
+                },
+                "locksPerKiloOp": 0,
+                "sustainerRate": 0,
+                "isLagged": false,
+                "isLaggedCount": 0,
+                "isLaggedTimeMicros": {
+                    "$numberLong": "0"
+                }
+            },
+            "globalLock": {
+                "totalTime": {
+                    "$numberLong": "1859834000"
+                },
+                "currentQueue": {
+                    "total": 0,
+                    "readers": 0,
+                    "writers": 0
+                },
+                "activeClients": {
+                    "total": 0,
+                    "readers": 0,
+                    "writers": 0
+                }
+            },
+            "indexBulkBuilder": {
+                "count": {
+                    "$numberLong": "9"
+                },
+                "resumed": {
+                    "$numberLong": "0"
+                },
+                "filesOpenedForExternalSort": {
+                    "$numberLong": "0"
+                },
+                "filesClosedForExternalSort": {
+                    "$numberLong": "0"
+                },
+                "spilledRanges": {
+                    "$numberLong": "0"
+                },
+                "bytesSpilledUncompressed": {
+                    "$numberLong": "0"
+                },
+                "bytesSpilled": {
+                    "$numberLong": "0"
+                }
+            },
+            "indexStats": {
+                "count": {
+                    "$numberLong": "0"
+                },
+                "features": {
+                    "2d": {
+                        "count": {
+                            "$numberLong": "0"
+                        },
+                        "accesses": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "2dsphere": {
+                        "count": {
+                            "$numberLong": "0"
+                        },
+                        "accesses": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "2dsphere_bucket": {
+                        "count": {
+                            "$numberLong": "0"
+                        },
+                        "accesses": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "collation": {
+                        "count": {
+                            "$numberLong": "0"
+                        },
+                        "accesses": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "compound": {
+                        "count": {
+                            "$numberLong": "0"
+                        },
+                        "accesses": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "hashed": {
+                        "count": {
+                            "$numberLong": "0"
+                        },
+                        "accesses": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "id": {
+                        "count": {
+                            "$numberLong": "0"
+                        },
+                        "accesses": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "normal": {
+                        "count": {
+                            "$numberLong": "0"
+                        },
+                        "accesses": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "partial": {
+                        "count": {
+                            "$numberLong": "0"
+                        },
+                        "accesses": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "single": {
+                        "count": {
+                            "$numberLong": "0"
+                        },
+                        "accesses": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "sparse": {
+                        "count": {
+                            "$numberLong": "0"
+                        },
+                        "accesses": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "text": {
+                        "count": {
+                            "$numberLong": "0"
+                        },
+                        "accesses": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "ttl": {
+                        "count": {
+                            "$numberLong": "0"
+                        },
+                        "accesses": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "unique": {
+                        "count": {
+                            "$numberLong": "0"
+                        },
+                        "accesses": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "wildcard": {
+                        "count": {
+                            "$numberLong": "0"
+                        },
+                        "accesses": {
+                            "$numberLong": "0"
+                        }
+                    }
+                }
+            },
+            "locks": {
+                "ParallelBatchWriterMode": {
+                    "acquireCount": {
+                        "r": {
+                            "$numberLong": "20104"
+                        },
+                        "W": {
+                            "$numberLong": "7"
+                        }
+                    },
+                    "acquireWaitCount": {
+                        "r": {
+                            "$numberLong": "2"
+                        },
+                        "W": {
+                            "$numberLong": "1"
+                        }
+                    },
+                    "timeAcquiringMicros": {
+                        "r": {
+                            "$numberLong": "13851"
+                        },
+                        "W": {
+                            "$numberLong": "321"
+                        }
+                    }
+                },
+                "FeatureCompatibilityVersion": {
+                    "acquireCount": {
+                        "r": {
+                            "$numberLong": "26789"
+                        },
+                        "w": {
+                            "$numberLong": "1311"
+                        }
+                    }
+                },
+                "ReplicationStateTransition": {
+                    "acquireCount": {
+                        "w": {
+                            "$numberLong": "48368"
+                        },
+                        "W": {
+                            "$numberLong": "2"
+                        }
+                    }
+                },
+                "Global": {
+                    "acquireCount": {
+                        "r": {
+                            "$numberLong": "45161"
+                        },
+                        "w": {
+                            "$numberLong": "19880"
+                        },
+                        "W": {
+                            "$numberLong": "8"
+                        }
+                    },
+                    "acquireWaitCount": {
+                        "r": {
+                            "$numberLong": "1"
+                        },
+                        "W": {
+                            "$numberLong": "1"
+                        }
+                    },
+                    "timeAcquiringMicros": {
+                        "r": {
+                            "$numberLong": "28459"
+                        },
+                        "W": {
+                            "$numberLong": "178"
+                        }
+                    }
+                },
+                "Database": {
+                    "acquireCount": {
+                        "r": {
+                            "$numberLong": "122"
+                        },
+                        "w": {
+                            "$numberLong": "19659"
+                        },
+                        "W": {
+                            "$numberLong": "5"
+                        }
+                    }
+                },
+                "Collection": {
+                    "acquireCount": {
+                        "r": {
+                            "$numberLong": "189"
+                        },
+                        "w": {
+                            "$numberLong": "19615"
+                        },
+                        "W": {
+                            "$numberLong": "20"
+                        }
+                    }
+                },
+                "Mutex": {
+                    "acquireCount": {
+                        "r": {
+                            "$numberLong": "23982"
+                        }
+                    }
+                },
+                "oplog": {
+                    "acquireCount": {
+                        "r": {
+                            "$numberLong": "4"
+                        },
+                        "w": {
+                            "$numberLong": "2"
+                        },
+                        "W": {
+                            "$numberLong": "9"
+                        }
+                    }
+                }
+            },
+            "logicalSessionRecordCache": {
+                "activeSessionsCount": 16,
+                "sessionsCollectionJobCount": 7,
+                "lastSessionsCollectionJobDurationMillis": 5,
+                "lastSessionsCollectionJobTimestamp": {
+                    "$date": 1692958129494
+                },
+                "lastSessionsCollectionJobEntriesRefreshed": 9,
+                "lastSessionsCollectionJobEntriesEnded": 6,
+                "lastSessionsCollectionJobCursorsClosed": 0,
+                "transactionReaperJobCount": 7,
+                "lastTransactionReaperJobDurationMillis": 0,
+                "lastTransactionReaperJobTimestamp": {
+                    "$date": 1692958129532
+                },
+                "lastTransactionReaperJobEntriesCleanedUp": 0,
+                "sessionCatalogSize": 1
+            },
+            "network": {
+                "bytesIn": {
+                    "$numberLong": "9548273"
+                },
+                "bytesOut": {
+                    "$numberLong": "49619104"
+                },
+                "physicalBytesIn": {
+                    "$numberLong": "7944399"
+                },
+                "physicalBytesOut": {
+                    "$numberLong": "48566283"
+                },
+                "numSlowDNSOperations": {
+                    "$numberLong": "0"
+                },
+                "numSlowSSLOperations": {
+                    "$numberLong": "0"
+                },
+                "numRequests": {
+                    "$numberLong": "32275"
+                },
+                "tcpFastOpen": {
+                    "kernelSetting": {
+                        "$numberLong": "3"
+                    },
+                    "serverSupported": true,
+                    "clientSupported": true,
+                    "accepted": {
+                        "$numberLong": "15"
+                    }
+                },
+                "compression": {
+                    "snappy": {
+                        "compressor": {
+                            "bytesIn": {
+                                "$numberLong": "3949696"
+                            },
+                            "bytesOut": {
+                                "$numberLong": "2749026"
+                            }
+                        },
+                        "decompressor": {
+                            "bytesIn": {
+                                "$numberLong": "2201664"
+                            },
+                            "bytesOut": {
+                                "$numberLong": "3534355"
+                            }
+                        }
+                    },
+                    "zstd": {
+                        "compressor": {
+                            "bytesIn": {
+                                "$numberLong": "0"
+                            },
+                            "bytesOut": {
+                                "$numberLong": "0"
+                            }
+                        },
+                        "decompressor": {
+                            "bytesIn": {
+                                "$numberLong": "0"
+                            },
+                            "bytesOut": {
+                                "$numberLong": "0"
+                            }
+                        }
+                    },
+                    "zlib": {
+                        "compressor": {
+                            "bytesIn": {
+                                "$numberLong": "0"
+                            },
+                            "bytesOut": {
+                                "$numberLong": "0"
+                            }
+                        },
+                        "decompressor": {
+                            "bytesIn": {
+                                "$numberLong": "0"
+                            },
+                            "bytesOut": {
+                                "$numberLong": "0"
+                            }
+                        }
+                    }
+                },
+                "serviceExecutors": {
+                    "passthrough": {
+                        "threadsRunning": 50,
+                        "clientsInTotal": 50,
+                        "clientsRunning": 50,
+                        "clientsWaitingForData": 0
+                    },
+                    "fixed": {
+                        "threadsRunning": 1,
+                        "clientsInTotal": 0,
+                        "clientsRunning": 0,
+                        "clientsWaitingForData": 0
+                    }
+                }
+            },
+            "opLatencies": {
+                "reads": {
+                    "latency": {
+                        "$numberLong": "344977"
+                    },
+                    "ops": {
+                        "$numberLong": "1879"
+                    }
+                },
+                "writes": {
+                    "latency": {
+                        "$numberLong": "122089"
+                    },
+                    "ops": {
+                        "$numberLong": "134"
+                    }
+                },
+                "commands": {
+                    "latency": {
+                        "$numberLong": "3081224"
+                    },
+                    "ops": {
+                        "$numberLong": "30247"
+                    }
+                },
+                "transactions": {
+                    "latency": {
+                        "$numberLong": "1103"
+                    },
+                    "ops": {
+                        "$numberLong": "1"
+                    }
+                }
+            },
+            "opWriteConcernCounters": {
+                "insert": {
+                    "wmajority": {
+                        "$numberLong": "5"
+                    },
+                    "wnum": {},
+                    "wtag": {},
+                    "none": {
+                        "$numberLong": "7"
+                    },
+                    "noneInfo": {
+                        "CWWC": {
+                            "wmajority": {
+                                "$numberLong": "0"
+                            },
+                            "wnum": {},
+                            "wtag": {}
+                        },
+                        "implicitDefault": {
+                            "wmajority": {
+                                "$numberLong": "0"
+                            },
+                            "wnum": {
+                                "1": {
+                                    "$numberLong": "7"
+                                }
+                            }
+                        }
+                    }
+                },
+                "update": {
+                    "wmajority": {
+                        "$numberLong": "134"
+                    },
+                    "wnum": {
+                        "1": {
+                            "$numberLong": "109"
+                        }
+                    },
+                    "wtag": {},
+                    "none": {
+                        "$numberLong": "10"
+                    },
+                    "noneInfo": {
+                        "CWWC": {
+                            "wmajority": {
+                                "$numberLong": "0"
+                            },
+                            "wnum": {},
+                            "wtag": {}
+                        },
+                        "implicitDefault": {
+                            "wmajority": {
+                                "$numberLong": "0"
+                            },
+                            "wnum": {
+                                "1": {
+                                    "$numberLong": "10"
+                                }
+                            }
+                        }
+                    }
+                },
+                "delete": {
+                    "wmajority": {
+                        "$numberLong": "411"
+                    },
+                    "wnum": {},
+                    "wtag": {},
+                    "none": {
+                        "$numberLong": "2"
+                    },
+                    "noneInfo": {
+                        "CWWC": {
+                            "wmajority": {
+                                "$numberLong": "0"
+                            },
+                            "wnum": {},
+                            "wtag": {}
+                        },
+                        "implicitDefault": {
+                            "wmajority": {
+                                "$numberLong": "0"
+                            },
+                            "wnum": {
+                                "1": {
+                                    "$numberLong": "2"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "opcounters": {
+                "insert": {
+                    "$numberLong": "12"
+                },
+                "query": {
+                    "$numberLong": "554"
+                },
+                "update": {
+                    "$numberLong": "253"
+                },
+                "delete": {
+                    "$numberLong": "413"
+                },
+                "getmore": {
+                    "$numberLong": "1300"
+                },
+                "command": {
+                    "$numberLong": "30389"
+                }
+            },
+            "opcountersRepl": {
+                "insert": {
+                    "$numberLong": "4"
+                },
+                "query": {
+                    "$numberLong": "0"
+                },
+                "update": {
+                    "$numberLong": "0"
+                },
+                "delete": {
+                    "$numberLong": "0"
+                },
+                "getmore": {
+                    "$numberLong": "0"
+                },
+                "command": {
+                    "$numberLong": "6"
+                }
+            },
+            "oplogTruncation": {
+                "totalTimeProcessingMicros": {
+                    "$numberLong": "52"
+                },
+                "processingMethod": "scanning",
+                "oplogMinRetentionHours": 24,
+                "totalTimeTruncatingMicros": {
+                    "$numberLong": "0"
+                },
+                "truncateCount": {
+                    "$numberLong": "0"
+                }
+            },
+            "readConcernCounters": {
+                "nonTransactionOps": {
+                    "none": {
+                        "$numberLong": "213"
+                    },
+                    "noneInfo": {
+                        "CWRC": {
+                            "local": {
+                                "$numberLong": "0"
+                            },
+                            "available": {
+                                "$numberLong": "0"
+                            },
+                            "majority": {
+                                "$numberLong": "0"
+                            }
+                        },
+                        "implicitDefault": {
+                            "local": {
+                                "$numberLong": "213"
+                            },
+                            "available": {
+                                "$numberLong": "0"
+                            }
+                        }
+                    },
+                    "local": {
+                        "$numberLong": "368"
+                    },
+                    "available": {
+                        "$numberLong": "0"
+                    },
+                    "majority": {
+                        "$numberLong": "0"
+                    },
+                    "snapshot": {
+                        "withClusterTime": {
+                            "$numberLong": "0"
+                        },
+                        "withoutClusterTime": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "linearizable": {
+                        "$numberLong": "0"
+                    }
+                },
+                "transactionOps": {
+                    "none": {
+                        "$numberLong": "0"
+                    },
+                    "noneInfo": {
+                        "CWRC": {
+                            "local": {
+                                "$numberLong": "0"
+                            },
+                            "majority": {
+                                "$numberLong": "0"
+                            }
+                        },
+                        "implicitDefault": {
+                            "local": {
+                                "$numberLong": "0"
+                            }
+                        }
+                    },
+                    "local": {
+                        "$numberLong": "0"
+                    },
+                    "majority": {
+                        "$numberLong": "0"
+                    },
+                    "snapshot": {
+                        "withClusterTime": {
+                            "$numberLong": "0"
+                        },
+                        "withoutClusterTime": {
+                            "$numberLong": "0"
+                        }
+                    }
+                }
+            },
+            "repl": {
+                "topologyVersion": {
+                    "processId": {
+                        "$oid": "64e876a8d4b39ffc57f842a7"
+                    },
+                    "counter": {
+                        "$numberLong": "7"
+                    }
+                },
+                "hosts": [
+                    "ac-xqaamls-shard-00-00.mns8wfq.mongodb.net:27017",
+                    "ac-xqaamls-shard-00-01.mns8wfq.mongodb.net:27017",
+                    "ac-xqaamls-shard-00-02.mns8wfq.mongodb.net:27017"
+                ],
+                "setName": "atlas-b5vr7t-shard-0",
+                "setVersion": 1,
+                "isWritablePrimary": true,
+                "secondary": false,
+                "primary": "ac-xqaamls-shard-00-01.mns8wfq.mongodb.net:27017",
+                "tags": {
+                    "nodeType": "ELECTABLE",
+                    "workloadType": "OPERATIONAL",
+                    "region": "AP_SOUTH_1",
+                    "provider": "AWS"
+                },
+                "me": "ac-xqaamls-shard-00-01.mns8wfq.mongodb.net:27017",
+                "electionId": {
+                    "$oid": "7fffffff0000000000000002"
+                },
+                "lastWrite": {
+                    "opTime": {
+                        "ts": {
+                            "$timestamp": {
+                                "t": 1692958184,
+                                "i": 1
+                            }
+                        },
+                        "t": {
+                            "$numberLong": "2"
+                        }
+                    },
+                    "lastWriteDate": {
+                        "$date": 1692958184000
+                    },
+                    "majorityOpTime": {
+                        "ts": {
+                            "$timestamp": {
+                                "t": 1692958184,
+                                "i": 1
+                            }
+                        },
+                        "t": {
+                            "$numberLong": "2"
+                        }
+                    },
+                    "majorityWriteDate": {
+                        "$date": 1692958184000
+                    }
+                },
+                "primaryOnlyServices": {
+                    "TenantMigrationDonorService": {
+                        "state": "running",
+                        "numInstances": 0
+                    },
+                    "TenantMigrationRecipientService": {
+                        "state": "running",
+                        "numInstances": 0
+                    },
+                    "ShardSplitDonorService": {
+                        "state": "running",
+                        "numInstances": 0
+                    }
+                },
+                "rbid": 1,
+                "userWriteBlockMode": 1
+            },
+            "scramCache": {
+                "SCRAM-SHA-1": {
+                    "count": {
+                        "$numberLong": "0"
+                    },
+                    "hits": {
+                        "$numberLong": "0"
+                    },
+                    "misses": {
+                        "$numberLong": "0"
+                    }
+                },
+                "SCRAM-SHA-256": {
+                    "count": {
+                        "$numberLong": "2"
+                    },
+                    "hits": {
+                        "$numberLong": "13"
+                    },
+                    "misses": {
+                        "$numberLong": "2"
+                    }
+                }
+            },
+            "security": {
+                "authentication": {
+                    "saslSupportedMechsReceived": {
+                        "$numberLong": "198"
+                    },
+                    "mechanisms": {
+                        "MONGODB-AWS": {
+                            "speculativeAuthenticate": {
+                                "received": {
+                                    "$numberLong": "0"
+                                },
+                                "successful": {
+                                    "$numberLong": "0"
+                                }
+                            },
+                            "clusterAuthenticate": {
+                                "received": {
+                                    "$numberLong": "0"
+                                },
+                                "successful": {
+                                    "$numberLong": "0"
+                                }
+                            },
+                            "authenticate": {
+                                "received": {
+                                    "$numberLong": "0"
+                                },
+                                "successful": {
+                                    "$numberLong": "0"
+                                }
+                            }
+                        },
+                        "MONGODB-X509": {
+                            "speculativeAuthenticate": {
+                                "received": {
+                                    "$numberLong": "0"
+                                },
+                                "successful": {
+                                    "$numberLong": "0"
+                                }
+                            },
+                            "clusterAuthenticate": {
+                                "received": {
+                                    "$numberLong": "0"
+                                },
+                                "successful": {
+                                    "$numberLong": "0"
+                                }
+                            },
+                            "authenticate": {
+                                "received": {
+                                    "$numberLong": "0"
+                                },
+                                "successful": {
+                                    "$numberLong": "0"
+                                }
+                            }
+                        },
+                        "SCRAM-SHA-1": {
+                            "speculativeAuthenticate": {
+                                "received": {
+                                    "$numberLong": "45"
+                                },
+                                "successful": {
+                                    "$numberLong": "38"
+                                }
+                            },
+                            "clusterAuthenticate": {
+                                "received": {
+                                    "$numberLong": "0"
+                                },
+                                "successful": {
+                                    "$numberLong": "0"
+                                }
+                            },
+                            "authenticate": {
+                                "received": {
+                                    "$numberLong": "52"
+                                },
+                                "successful": {
+                                    "$numberLong": "38"
+                                }
+                            }
+                        },
+                        "SCRAM-SHA-256": {
+                            "speculativeAuthenticate": {
+                                "received": {
+                                    "$numberLong": "144"
+                                },
+                                "successful": {
+                                    "$numberLong": "142"
+                                }
+                            },
+                            "clusterAuthenticate": {
+                                "received": {
+                                    "$numberLong": "178"
+                                },
+                                "successful": {
+                                    "$numberLong": "177"
+                                }
+                            },
+                            "authenticate": {
+                                "received": {
+                                    "$numberLong": "198"
+                                },
+                                "successful": {
+                                    "$numberLong": "196"
+                                }
+                            }
+                        }
+                    }
+                },
+                "SSLServerSubjectName": "CN=*.mns8wfq.mongodb.net",
+                "SSLServerHasCertificateAuthority": true,
+                "SSLServerCertificateExpirationDate": {
+                    "$date": 1700728684000
+                }
+            },
+            "storageEngine": {
+                "name": "wiredTiger",
+                "supportsCommittedReads": true,
+                "oldestRequiredTimestampForCrashRecovery": {
+                    "$timestamp": {
+                        "t": 1692958144,
+                        "i": 1
+                    }
+                },
+                "supportsPendingDrops": true,
+                "dropPendingIdents": {
+                    "$numberLong": "0"
+                },
+                "supportsSnapshotReadConcern": true,
+                "readOnly": false,
+                "persistent": true,
+                "backupCursorOpen": false
+            },
+            "tcmalloc": {
+                "generic": {
+                    "current_allocated_bytes": 122854504,
+                    "heap_size": 152223744
+                },
+                "tcmalloc": {
+                    "pageheap_free_bytes": 20451328,
+                    "pageheap_unmapped_bytes": 36864,
+                    "max_total_thread_cache_bytes": 242221056,
+                    "current_total_thread_cache_bytes": 6237640,
+                    "total_free_bytes": 8881048,
+                    "central_cache_free_bytes": 550160,
+                    "transfer_cache_free_bytes": 2093248,
+                    "thread_cache_free_bytes": 6237640,
+                    "aggressive_memory_decommit": 0,
+                    "pageheap_committed_bytes": 152186880,
+                    "pageheap_scavenge_count": 38,
+                    "pageheap_commit_count": 162,
+                    "pageheap_total_commit_bytes": 165294080,
+                    "pageheap_decommit_count": 38,
+                    "pageheap_total_decommit_bytes": 13107200,
+                    "pageheap_reserve_count": 70,
+                    "pageheap_total_reserve_bytes": 152223744,
+                    "spinlock_total_delay_ns": 16131790,
+                    "release_rate": 1,
+                    "formattedString": "------------------------------------------------\nMALLOC:      122854952 (  117.2 MiB) Bytes in use by application\nMALLOC: +     20451328 (   19.5 MiB) Bytes in page heap freelist\nMALLOC: +       550160 (    0.5 MiB) Bytes in central cache freelist\nMALLOC: +      2093248 (    2.0 MiB) Bytes in transfer cache freelist\nMALLOC: +      6237192 (    5.9 MiB) Bytes in thread cache freelists\nMALLOC: +      3145728 (    3.0 MiB) Bytes in malloc metadata\nMALLOC:   ------------\nMALLOC: =    155332608 (  148.1 MiB) Actual memory used (physical + swap)\nMALLOC: +        36864 (    0.0 MiB) Bytes released to OS (aka unmapped)\nMALLOC:   ------------\nMALLOC: =    155369472 (  148.2 MiB) Virtual address space used\nMALLOC:\nMALLOC:           2809              Spans in use\nMALLOC:            115              Thread heaps in use\nMALLOC:           4096              Tcmalloc page size\n------------------------------------------------\nCall ReleaseFreeMemory() to release freelist memory to the OS (via madvise()).\nBytes released to the OS take up virtual address space but no physical memory.\n"
+                }
+            },
+            "tenantMigrations": {
+                "currentMigrationsDonating": {
+                    "$numberLong": "0"
+                },
+                "currentMigrationsReceiving": {
+                    "$numberLong": "0"
+                },
+                "totalSuccessfulMigrationsDonated": {
+                    "$numberLong": "0"
+                },
+                "totalSuccessfulMigrationsReceived": {
+                    "$numberLong": "0"
+                },
+                "totalFailedMigrationsDonated": {
+                    "$numberLong": "0"
+                },
+                "totalFailedMigrationsReceived": {
+                    "$numberLong": "0"
+                }
+            },
+            "trafficRecording": {
+                "running": false
+            },
+            "transactions": {
+                "retriedCommandsCount": {
+                    "$numberLong": "0"
+                },
+                "retriedStatementsCount": {
+                    "$numberLong": "0"
+                },
+                "transactionsCollectionWriteCount": {
+                    "$numberLong": "1"
+                },
+                "currentActive": {
+                    "$numberLong": "0"
+                },
+                "currentInactive": {
+                    "$numberLong": "0"
+                },
+                "currentOpen": {
+                    "$numberLong": "0"
+                },
+                "totalAborted": {
+                    "$numberLong": "0"
+                },
+                "totalCommitted": {
+                    "$numberLong": "1"
+                },
+                "totalStarted": {
+                    "$numberLong": "1"
+                },
+                "totalPrepared": {
+                    "$numberLong": "0"
+                },
+                "totalPreparedThenCommitted": {
+                    "$numberLong": "0"
+                },
+                "totalPreparedThenAborted": {
+                    "$numberLong": "0"
+                },
+                "currentPrepared": {
+                    "$numberLong": "0"
+                },
+                "lastCommittedTransaction": {
+                    "operationCount": {
+                        "$numberLong": "2"
+                    },
+                    "oplogOperationBytes": {
+                        "$numberLong": "914"
+                    },
+                    "writeConcern": {
+                        "w": "majority",
+                        "wtimeout": 0,
+                        "provenance": "implicitDefault"
+                    }
+                }
+            },
+            "transportSecurity": {
+                "1.0": {
+                    "$numberLong": "0"
+                },
+                "1.1": {
+                    "$numberLong": "0"
+                },
+                "1.2": {
+                    "$numberLong": "578"
+                },
+                "1.3": {
+                    "$numberLong": "0"
+                },
+                "unknown": {
+                    "$numberLong": "0"
+                }
+            },
+            "twoPhaseCommitCoordinator": {
+                "totalCreated": {
+                    "$numberLong": "0"
+                },
+                "totalStartedTwoPhaseCommit": {
+                    "$numberLong": "0"
+                },
+                "totalAbortedTwoPhaseCommit": {
+                    "$numberLong": "0"
+                },
+                "totalCommittedTwoPhaseCommit": {
+                    "$numberLong": "0"
+                },
+                "currentInSteps": {
+                    "writingParticipantList": {
+                        "$numberLong": "0"
+                    },
+                    "waitingForVotes": {
+                        "$numberLong": "0"
+                    },
+                    "writingDecision": {
+                        "$numberLong": "0"
+                    },
+                    "waitingForDecisionAcks": {
+                        "$numberLong": "0"
+                    },
+                    "deletingCoordinatorDoc": {
+                        "$numberLong": "0"
+                    }
+                }
+            },
+            "watchdog": {
+                "checkGeneration": {
+                    "$numberLong": "555"
+                },
+                "monitorGeneration": {
+                    "$numberLong": "0"
+                },
+                "monitorPeriod": 60
+            },
+            "wiredTiger": {
+                "uri": "statistics:",
+                "autocommit": {
+                    "retries for readonly operations": 0,
+                    "retries for update operations": 0
+                },
+                "block-cache": {
+                    "cached blocks updated": 0,
+                    "cached bytes updated": 0,
+                    "evicted blocks": 0,
+                    "file size causing bypass": 0,
+                    "lookups": 0,
+                    "number of blocks not evicted due to overhead": 0,
+                    "number of bypasses because no-write-allocate setting was on": 0,
+                    "number of bypasses due to overhead on put": 0,
+                    "number of bypasses on get": 0,
+                    "number of bypasses on put because file is too small": 0,
+                    "number of eviction passes": 0,
+                    "number of hits": 0,
+                    "number of misses": 0,
+                    "number of put bypasses on checkpoint I/O": 0,
+                    "removed blocks": 0,
+                    "total blocks": 0,
+                    "total blocks inserted on read path": 0,
+                    "total blocks inserted on write path": 0,
+                    "total bytes": 0,
+                    "total bytes inserted on read path": 0,
+                    "total bytes inserted on write path": 0
+                },
+                "block-manager": {
+                    "blocks pre-loaded": 2,
+                    "blocks read": 175,
+                    "blocks written": 900,
+                    "bytes read": 716800,
+                    "bytes read via memory map API": 0,
+                    "bytes read via system call API": 0,
+                    "bytes written": 6668288,
+                    "bytes written for checkpoint": 6660096,
+                    "bytes written via memory map API": 0,
+                    "bytes written via system call API": 0,
+                    "mapped blocks read": 0,
+                    "mapped bytes read": 0,
+                    "number of times the file was remapped because it changed size via fallocate or truncate": 0,
+                    "number of times the region was remapped via write": 0
+                },
+                "cache": {
+                    "application threads page read from disk to cache count": 6,
+                    "application threads page read from disk to cache time (usecs)": 18,
+                    "application threads page write from cache to disk count": 491,
+                    "application threads page write from cache to disk time (usecs)": 13605,
+                    "bytes allocated for updates": 499043,
+                    "bytes belonging to page images in the cache": 251,
+                    "bytes belonging to the history store table in the cache": 41476,
+                    "bytes currently in the cache": 526288,
+                    "bytes dirty in the cache cumulative": 8870419,
+                    "bytes not belonging to page images in the cache": 526036,
+                    "bytes read into cache": 362,
+                    "bytes written from cache": 4575449,
+                    "checkpoint blocked page eviction": 0,
+                    "checkpoint of history store file blocked non-history store page eviction": 0,
+                    "eviction calls to get a page": 78,
+                    "eviction calls to get a page found queue empty": 78,
+                    "eviction calls to get a page found queue empty after locking": 0,
+                    "eviction currently operating in aggressive mode": 0,
+                    "eviction empty score": 0,
+                    "eviction gave up due to detecting an out of order on disk value behind the last update on the chain": 0,
+                    "eviction gave up due to detecting an out of order tombstone ahead of the selected on disk update": 0,
+                    "eviction gave up due to detecting an out of order tombstone ahead of the selected on disk update after validating the update chain": 0,
+                    "eviction gave up due to detecting out of order timestamps on the update chain after the selected on disk update": 0,
+                    "eviction gave up due to needing to remove a record from the history store but checkpoint is running": 0,
+                    "eviction passes of a file": 0,
+                    "eviction server candidate queue empty when topping up": 0,
+                    "eviction server candidate queue not empty when topping up": 0,
+                    "eviction server evicting pages": 0,
+                    "eviction server slept, because we did not make progress with eviction": 0,
+                    "eviction server unable to reach eviction goal": 0,
+                    "eviction server waiting for a leaf page": 13,
+                    "eviction state": 64,
+                    "eviction walk most recent sleeps for checkpoint handle gathering": 0,
+                    "eviction walk target pages histogram - 0-9": 0,
+                    "eviction walk target pages histogram - 10-31": 0,
+                    "eviction walk target pages histogram - 128 and higher": 0,
+                    "eviction walk target pages histogram - 32-63": 0,
+                    "eviction walk target pages histogram - 64-128": 0,
+                    "eviction walk target pages reduced due to history store cache pressure": 0,
+                    "eviction walk target strategy both clean and dirty pages": 0,
+                    "eviction walk target strategy only clean pages": 0,
+                    "eviction walk target strategy only dirty pages": 0,
+                    "eviction walks abandoned": 0,
+                    "eviction walks gave up because they restarted their walk twice": 0,
+                    "eviction walks gave up because they saw too many pages and found no candidates": 0,
+                    "eviction walks gave up because they saw too many pages and found too few candidates": 0,
+                    "eviction walks reached end of tree": 0,
+                    "eviction walks restarted": 0,
+                    "eviction walks started from root of tree": 0,
+                    "eviction walks started from saved location in tree": 0,
+                    "eviction worker thread active": 4,
+                    "eviction worker thread created": 0,
+                    "eviction worker thread evicting pages": 0,
+                    "eviction worker thread removed": 0,
+                    "eviction worker thread stable number": 0,
+                    "files with active eviction walks": 0,
+                    "files with new eviction walks started": 0,
+                    "force re-tuning of eviction workers once in a while": 0,
+                    "forced eviction - do not retry count to evict pages selected to evict during reconciliation": 0,
+                    "forced eviction - history store pages failed to evict while session has history store cursor open": 0,
+                    "forced eviction - history store pages selected while session has history store cursor open": 0,
+                    "forced eviction - history store pages successfully evicted while session has history store cursor open": 0,
+                    "forced eviction - pages evicted that were clean count": 0,
+                    "forced eviction - pages evicted that were clean time (usecs)": 0,
+                    "forced eviction - pages evicted that were dirty count": 0,
+                    "forced eviction - pages evicted that were dirty time (usecs)": 0,
+                    "forced eviction - pages selected because of a large number of updates to a single item": 0,
+                    "forced eviction - pages selected because of too many deleted items count": 0,
+                    "forced eviction - pages selected count": 0,
+                    "forced eviction - pages selected unable to be evicted count": 0,
+                    "forced eviction - pages selected unable to be evicted time": 0,
+                    "hazard pointer blocked page eviction": 0,
+                    "hazard pointer check calls": 0,
+                    "hazard pointer check entries walked": 0,
+                    "hazard pointer maximum array length": 0,
+                    "history store table insert calls": 103,
+                    "history store table insert calls that returned restart": 0,
+                    "history store table max on-disk size": 0,
+                    "history store table on-disk size": 36864,
+                    "history store table out-of-order resolved updates that lose their durable timestamp": 0,
+                    "history store table out-of-order updates that were fixed up by reinserting with the fixed timestamp": 0,
+                    "history store table reads": 0,
+                    "history store table reads missed": 0,
+                    "history store table reads requiring squashed modifies": 0,
+                    "history store table truncation by rollback to stable to remove an unstable update": 0,
+                    "history store table truncation by rollback to stable to remove an update": 0,
+                    "history store table truncation to remove an update": 0,
+                    "history store table truncation to remove range of updates due to key being removed from the data page during reconciliation": 0,
+                    "history store table truncation to remove range of updates due to out-of-order timestamp update on data page": 0,
+                    "history store table writes requiring squashed modifies": 11,
+                    "in-memory page passed criteria to be split": 0,
+                    "in-memory page splits": 0,
+                    "internal pages evicted": 0,
+                    "internal pages queued for eviction": 0,
+                    "internal pages seen by eviction walk": 0,
+                    "internal pages seen by eviction walk that are already queued": 0,
+                    "internal pages split during eviction": 0,
+                    "leaf pages split during eviction": 0,
+                    "maximum bytes configured": 536870912,
+                    "maximum milliseconds spent at a single eviction": 0,
+                    "maximum page size seen at eviction": 0,
+                    "modified pages evicted": 9,
+                    "modified pages evicted by application threads": 0,
+                    "operations timed out waiting for space in cache": 0,
+                    "overflow pages read into cache": 0,
+                    "page split during eviction deepened the tree": 0,
+                    "page written requiring history store records": 8,
+                    "pages currently held in the cache": 94,
+                    "pages evicted by application threads": 0,
+                    "pages evicted in parallel with checkpoint": 0,
+                    "pages queued for eviction": 0,
+                    "pages queued for eviction post lru sorting": 0,
+                    "pages queued for urgent eviction": 0,
+                    "pages queued for urgent eviction during walk": 0,
+                    "pages queued for urgent eviction from history store due to high dirty content": 0,
+                    "pages read into cache": 6,
+                    "pages read into cache after truncate": 42,
+                    "pages read into cache after truncate in prepare state": 0,
+                    "pages removed from the ordinary queue to be queued for urgent eviction": 0,
+                    "pages requested from the cache": 14401,
+                    "pages seen by eviction walk": 0,
+                    "pages seen by eviction walk that are already queued": 0,
+                    "pages selected for eviction unable to be evicted": 0,
+                    "pages selected for eviction unable to be evicted because of active children on an internal page": 0,
+                    "pages selected for eviction unable to be evicted because of failure in reconciliation": 0,
+                    "pages selected for eviction unable to be evicted because of race between checkpoint and out of order timestamps handling": 0,
+                    "pages walked for eviction": 0,
+                    "pages written from cache": 491,
+                    "pages written requiring in-memory restoration": 0,
+                    "percentage overhead": 8,
+                    "the number of times full update inserted to history store": 103,
+                    "the number of times reverse modify inserted to history store": 0,
+                    "total milliseconds spent inside reentrant history store evictions in a reconciliation": 0,
+                    "tracked bytes belonging to internal pages in the cache": 22734,
+                    "tracked bytes belonging to leaf pages in the cache": 503554,
+                    "tracked dirty bytes in the cache": 111681,
+                    "tracked dirty pages in the cache": 2,
+                    "unmodified pages evicted": 9
+                },
+                "capacity": {
+                    "background fsync file handles considered": 0,
+                    "background fsync file handles synced": 0,
+                    "background fsync time (msecs)": 0,
+                    "bytes read": 24576,
+                    "bytes written for checkpoint": 3524704,
+                    "bytes written for eviction": 129,
+                    "bytes written for log": 359936,
+                    "bytes written total": 3884769,
+                    "threshold to call fsync": 0,
+                    "time waiting due to total capacity (usecs)": 0,
+                    "time waiting during checkpoint (usecs)": 0,
+                    "time waiting during eviction (usecs)": 0,
+                    "time waiting during logging (usecs)": 0,
+                    "time waiting during read (usecs)": 0
+                },
+                "checkpoint-cleanup": {
+                    "pages added for eviction": 4,
+                    "pages removed": 0,
+                    "pages skipped during tree walk": 0,
+                    "pages visited": 201
+                },
+                "connection": {
+                    "auto adjusting condition resets": 528,
+                    "auto adjusting condition wait calls": 12015,
+                    "auto adjusting condition wait raced to update timeout and skipped updating": 0,
+                    "detected system time went backwards": 0,
+                    "files currently open": 55,
+                    "hash bucket array size for data handles": 512,
+                    "hash bucket array size general": 512,
+                    "memory allocations": 195487,
+                    "memory frees": 189497,
+                    "memory re-allocations": 16627,
+                    "pthread mutex condition wait calls": 30920,
+                    "pthread mutex shared lock read-lock calls": 83078,
+                    "pthread mutex shared lock write-lock calls": 7629,
+                    "total fsync I/Os": 746,
+                    "total read I/Os": 289,
+                    "total write I/Os": 1371
+                },
+                "cursor": {
+                    "Total number of entries skipped by cursor next calls": 139,
+                    "Total number of entries skipped by cursor prev calls": 0,
+                    "Total number of entries skipped to position the history store cursor": 0,
+                    "Total number of times a search near has exited due to prefix config": 5,
+                    "cached cursor count": 148,
+                    "cursor bulk loaded cursor insert calls": 2,
+                    "cursor close calls that result in cache": 20157,
+                    "cursor create calls": 717,
+                    "cursor insert calls": 1368,
+                    "cursor insert key and value bytes": 526074,
+                    "cursor modify calls": 229,
+                    "cursor modify key and value bytes affected": 16900,
+                    "cursor modify value bytes modified": 1840,
+                    "cursor next calls": 6298,
+                    "cursor next calls that skip due to a globally visible history store tombstone": 0,
+                    "cursor next calls that skip greater than or equal to 100 entries": 0,
+                    "cursor next calls that skip less than 100 entries": 6293,
+                    "cursor operation restarted": 0,
+                    "cursor prev calls": 446,
+                    "cursor prev calls that skip due to a globally visible history store tombstone": 0,
+                    "cursor prev calls that skip greater than or equal to 100 entries": 0,
+                    "cursor prev calls that skip less than 100 entries": 446,
+                    "cursor remove calls": 140,
+                    "cursor remove key bytes removed": 2518,
+                    "cursor reserve calls": 0,
+                    "cursor reset calls": 34722,
+                    "cursor search calls": 8967,
+                    "cursor search history store calls": 0,
+                    "cursor search near calls": 1373,
+                    "cursor sweep buckets": 44930,
+                    "cursor sweep cursors closed": 5,
+                    "cursor sweep cursors examined": 2745,
+                    "cursor sweeps": 3080,
+                    "cursor truncate calls": 0,
+                    "cursor update calls": 0,
+                    "cursor update key and value bytes": 0,
+                    "cursor update value size change": 0,
+                    "cursors reused from cache": 20004,
+                    "open cursor count": 10
+                },
+                "data-handle": {
+                    "connection data handle size": 448,
+                    "connection data handles currently active": 104,
+                    "connection sweep candidate became referenced": 0,
+                    "connection sweep dhandles closed": 6,
+                    "connection sweep dhandles removed from hash list": 159,
+                    "connection sweep time-of-death sets": 1509,
+                    "connection sweeps": 191,
+                    "connection sweeps skipped due to checkpoint gathering handles": 0,
+                    "session dhandles swept": 293,
+                    "session sweep attempts": 1106
+                },
+                "lock": {
+                    "checkpoint lock acquisitions": 32,
+                    "checkpoint lock application thread wait time (usecs)": 0,
+                    "checkpoint lock internal thread wait time (usecs)": 0,
+                    "dhandle lock application thread time waiting (usecs)": 0,
+                    "dhandle lock internal thread time waiting (usecs)": 0,
+                    "dhandle read lock acquisitions": 8084,
+                    "dhandle write lock acquisitions": 430,
+                    "durable timestamp queue lock application thread time waiting (usecs)": 0,
+                    "durable timestamp queue lock internal thread time waiting (usecs)": 0,
+                    "durable timestamp queue read lock acquisitions": 0,
+                    "durable timestamp queue write lock acquisitions": 0,
+                    "metadata lock acquisitions": 32,
+                    "metadata lock application thread wait time (usecs)": 0,
+                    "metadata lock internal thread wait time (usecs)": 0,
+                    "read timestamp queue lock application thread time waiting (usecs)": 0,
+                    "read timestamp queue lock internal thread time waiting (usecs)": 0,
+                    "read timestamp queue read lock acquisitions": 0,
+                    "read timestamp queue write lock acquisitions": 0,
+                    "schema lock acquisitions": 124,
+                    "schema lock application thread wait time (usecs)": 0,
+                    "schema lock internal thread wait time (usecs)": 0,
+                    "table lock application thread time waiting for the table lock (usecs)": 0,
+                    "table lock internal thread time waiting for the table lock (usecs)": 2520,
+                    "table read lock acquisitions": 0,
+                    "table write lock acquisitions": 3944,
+                    "txn global lock application thread time waiting (usecs)": 0,
+                    "txn global lock internal thread time waiting (usecs)": 0,
+                    "txn global read lock acquisitions": 744,
+                    "txn global write lock acquisitions": 938
+                },
+                "log": {
+                    "busy returns attempting to switch slots": 0,
+                    "force log remove time sleeping (usecs)": 0,
+                    "log bytes of payload data": 274693,
+                    "log bytes written": 359808,
+                    "log files manually zero-filled": 0,
+                    "log flush operations": 18629,
+                    "log force write operations": 20717,
+                    "log force write operations skipped": 20440,
+                    "log records compressed": 226,
+                    "log records not compressed": 418,
+                    "log records too small to compress": 522,
+                    "log release advances write LSN": 98,
+                    "log scan operations": 0,
+                    "log scan records requiring two reads": 0,
+                    "log server thread advances write LSN": 277,
+                    "log server thread write LSN walk skipped": 6395,
+                    "log sync operations": 365,
+                    "log sync time duration (usecs)": 331939,
+                    "log sync_dir operations": 1,
+                    "log sync_dir time duration (usecs)": 1,
+                    "log write operations": 1166,
+                    "logging bytes consolidated": 359296,
+                    "maximum log file size": 104857600,
+                    "number of pre-allocated log files to create": 2,
+                    "pre-allocated log files not ready and missed": 1,
+                    "pre-allocated log files prepared": 2,
+                    "pre-allocated log files used": 0,
+                    "records processed by log scan": 0,
+                    "slot close lost race": 0,
+                    "slot close unbuffered waits": 0,
+                    "slot closures": 375,
+                    "slot join atomic update races": 0,
+                    "slot join calls atomic updates raced": 0,
+                    "slot join calls did not yield": 1166,
+                    "slot join calls found active slot closed": 0,
+                    "slot join calls slept": 0,
+                    "slot join calls yielded": 0,
+                    "slot join found active slot closed": 0,
+                    "slot joins yield time (usecs)": 0,
+                    "slot transitions unable to find free slot": 0,
+                    "slot unbuffered writes": 0,
+                    "total in-memory size of compressed records": 400093,
+                    "total log buffer size": 33554432,
+                    "total size of compressed records": 156540,
+                    "written slots coalesced": 0,
+                    "yields waiting for previous log file close": 0
+                },
+                "perf": {
+                    "file system read latency histogram (bucket 1) - 10-49ms": 0,
+                    "file system read latency histogram (bucket 2) - 50-99ms": 0,
+                    "file system read latency histogram (bucket 3) - 100-249ms": 0,
+                    "file system read latency histogram (bucket 4) - 250-499ms": 0,
+                    "file system read latency histogram (bucket 5) - 500-999ms": 0,
+                    "file system read latency histogram (bucket 6) - 1000ms+": 0,
+                    "file system write latency histogram (bucket 1) - 10-49ms": 0,
+                    "file system write latency histogram (bucket 2) - 50-99ms": 0,
+                    "file system write latency histogram (bucket 3) - 100-249ms": 0,
+                    "file system write latency histogram (bucket 4) - 250-499ms": 0,
+                    "file system write latency histogram (bucket 5) - 500-999ms": 0,
+                    "file system write latency histogram (bucket 6) - 1000ms+": 0,
+                    "operation read latency histogram (bucket 1) - 100-249us": 0,
+                    "operation read latency histogram (bucket 2) - 250-499us": 0,
+                    "operation read latency histogram (bucket 3) - 500-999us": 0,
+                    "operation read latency histogram (bucket 4) - 1000-9999us": 0,
+                    "operation read latency histogram (bucket 5) - 10000us+": 0,
+                    "operation write latency histogram (bucket 1) - 100-249us": 0,
+                    "operation write latency histogram (bucket 2) - 250-499us": 0,
+                    "operation write latency histogram (bucket 3) - 500-999us": 0,
+                    "operation write latency histogram (bucket 4) - 1000-9999us": 0,
+                    "operation write latency histogram (bucket 5) - 10000us+": 0
+                },
+                "reconciliation": {
+                    "approximate byte size of timestamps in pages written": 11056,
+                    "approximate byte size of transaction IDs in pages written": 8048,
+                    "fast-path pages deleted": 0,
+                    "leaf-page overflow keys": 0,
+                    "maximum milliseconds spent in a reconciliation call": 0,
+                    "maximum milliseconds spent in building a disk image in a reconciliation": 0,
+                    "maximum milliseconds spent in moving updates to the history store in a reconciliation": 0,
+                    "page reconciliation calls": 411,
+                    "page reconciliation calls for eviction": 9,
+                    "page reconciliation calls that resulted in values with prepared transaction metadata": 0,
+                    "page reconciliation calls that resulted in values with timestamps": 38,
+                    "page reconciliation calls that resulted in values with transaction ids": 70,
+                    "pages deleted": 22,
+                    "pages written including an aggregated newest start durable timestamp ": 40,
+                    "pages written including an aggregated newest stop durable timestamp ": 25,
+                    "pages written including an aggregated newest stop timestamp ": 8,
+                    "pages written including an aggregated newest stop transaction ID": 8,
+                    "pages written including an aggregated newest transaction ID ": 46,
+                    "pages written including an aggregated oldest start timestamp ": 20,
+                    "pages written including an aggregated prepare": 0,
+                    "pages written including at least one prepare state": 0,
+                    "pages written including at least one start durable timestamp": 40,
+                    "pages written including at least one start timestamp": 40,
+                    "pages written including at least one start transaction ID": 109,
+                    "pages written including at least one stop durable timestamp": 25,
+                    "pages written including at least one stop timestamp": 25,
+                    "pages written including at least one stop transaction ID": 25,
+                    "records written including a prepare state": 0,
+                    "records written including a start durable timestamp": 441,
+                    "records written including a start timestamp": 441,
+                    "records written including a start transaction ID": 756,
+                    "records written including a stop durable timestamp": 250,
+                    "records written including a stop timestamp": 250,
+                    "records written including a stop transaction ID": 250,
+                    "split bytes currently awaiting free": 0,
+                    "split objects currently awaiting free": 0
+                },
+                "session": {
+                    "attempts to remove a local object and the object is in use": 0,
+                    "flush_tier operation calls": 0,
+                    "flush_tier tables skipped due to no checkpoint": 0,
+                    "flush_tier tables switched": 0,
+                    "local objects removed": 0,
+                    "open session count": 17,
+                    "session query timestamp calls": 10,
+                    "table alter failed calls": 0,
+                    "table alter successful calls": 0,
+                    "table alter triggering checkpoint calls": 0,
+                    "table alter unchanged and skipped": 0,
+                    "table compact failed calls": 0,
+                    "table compact failed calls due to cache pressure": 0,
+                    "table compact running": 0,
+                    "table compact skipped as process would not reduce file size": 0,
+                    "table compact successful calls": 0,
+                    "table compact timeout": 0,
+                    "table create failed calls": 0,
+                    "table create successful calls": 57,
+                    "table drop failed calls": 0,
+                    "table drop successful calls": 6,
+                    "table rename failed calls": 0,
+                    "table rename successful calls": 0,
+                    "table salvage failed calls": 0,
+                    "table salvage successful calls": 0,
+                    "table truncate failed calls": 0,
+                    "table truncate successful calls": 0,
+                    "table verify failed calls": 0,
+                    "table verify successful calls": 0,
+                    "tiered operations dequeued and processed": 0,
+                    "tiered operations scheduled": 0,
+                    "tiered storage local retention time (secs)": 0
+                },
+                "thread-state": {
+                    "active filesystem fsync calls": 0,
+                    "active filesystem read calls": 0,
+                    "active filesystem write calls": 0
+                },
+                "thread-yield": {
+                    "application thread time evicting (usecs)": 0,
+                    "application thread time waiting for cache (usecs)": 0,
+                    "connection close blocked waiting for transaction state stabilization": 0,
+                    "connection close yielded for lsm manager shutdown": 0,
+                    "data handle lock yielded": 0,
+                    "get reference for page index and slot time sleeping (usecs)": 0,
+                    "page access yielded due to prepare state change": 0,
+                    "page acquire busy blocked": 0,
+                    "page acquire eviction blocked": 0,
+                    "page acquire locked blocked": 0,
+                    "page acquire read blocked": 0,
+                    "page acquire time sleeping (usecs)": 0,
+                    "page delete rollback time sleeping for state change (usecs)": 0,
+                    "page reconciliation yielded due to child modification": 0
+                },
+                "transaction": {
+                    "Number of prepared updates": 0,
+                    "Number of prepared updates committed": 0,
+                    "Number of prepared updates repeated on the same key": 0,
+                    "Number of prepared updates rolled back": 0,
+                    "checkpoint has acquired a snapshot for its transaction": 0,
+                    "oldest pinned transaction ID rolled back for eviction": 0,
+                    "prepared transactions": 0,
+                    "prepared transactions committed": 0,
+                    "prepared transactions currently active": 0,
+                    "prepared transactions rolled back": 0,
+                    "query timestamp calls": 24652,
+                    "race to read prepared update retry": 0,
+                    "rollback to stable calls": 0,
+                    "rollback to stable history store records with stop timestamps older than newer records": 0,
+                    "rollback to stable inconsistent checkpoint": 0,
+                    "rollback to stable keys removed": 0,
+                    "rollback to stable keys restored": 0,
+                    "rollback to stable pages visited": 0,
+                    "rollback to stable restored tombstones from history store": 0,
+                    "rollback to stable restored updates from history store": 0,
+                    "rollback to stable skipping delete rle": 0,
+                    "rollback to stable skipping stable rle": 0,
+                    "rollback to stable sweeping history store keys": 0,
+                    "rollback to stable tree walk skipping pages": 0,
+                    "rollback to stable updates aborted": 0,
+                    "rollback to stable updates removed from history store": 0,
+                    "sessions scanned in each walk of concurrent sessions": 480314,
+                    "set timestamp calls": 419,
+                    "set timestamp durable calls": 3,
+                    "set timestamp durable updates": 3,
+                    "set timestamp oldest calls": 182,
+                    "set timestamp oldest updates": 182,
+                    "set timestamp stable calls": 237,
+                    "set timestamp stable updates": 235,
+                    "transaction begins": 8900,
+                    "transaction checkpoint currently running": 0,
+                    "transaction checkpoint currently running for history store file": 0,
+                    "transaction checkpoint generation": 33,
+                    "transaction checkpoint history store file duration (usecs)": 214,
+                    "transaction checkpoint max time (msecs)": 34,
+                    "transaction checkpoint min time (msecs)": 7,
+                    "transaction checkpoint most recent duration for gathering all handles (usecs)": 195,
+                    "transaction checkpoint most recent duration for gathering applied handles (usecs)": 49,
+                    "transaction checkpoint most recent duration for gathering skipped handles (usecs)": 67,
+                    "transaction checkpoint most recent handles applied": 6,
+                    "transaction checkpoint most recent handles skipped": 45,
+                    "transaction checkpoint most recent handles walked": 110,
+                    "transaction checkpoint most recent time (msecs)": 16,
+                    "transaction checkpoint prepare currently running": 0,
+                    "transaction checkpoint prepare max time (msecs)": 0,
+                    "transaction checkpoint prepare min time (msecs)": 0,
+                    "transaction checkpoint prepare most recent time (msecs)": 0,
+                    "transaction checkpoint prepare total time (msecs)": 0,
+                    "transaction checkpoint scrub dirty target": 0,
+                    "transaction checkpoint scrub time (msecs)": 0,
+                    "transaction checkpoint stop timing stress active": 0,
+                    "transaction checkpoint total time (msecs)": 392,
+                    "transaction checkpoints": 32,
+                    "transaction checkpoints due to obsolete pages": 0,
+                    "transaction checkpoints skipped because database was clean": 0,
+                    "transaction fsync calls for checkpoint after allocating the transaction ID": 32,
+                    "transaction fsync duration for checkpoint after allocating the transaction ID (usecs)": 8862,
+                    "transaction range of IDs currently pinned": 0,
+                    "transaction range of IDs currently pinned by a checkpoint": 0,
+                    "transaction range of timestamps currently pinned": {
+                        "$numberLong": "1288490188800"
+                    },
+                    "transaction range of timestamps pinned by a checkpoint": {
+                        "$numberLong": "7271200033775550465"
+                    },
+                    "transaction range of timestamps pinned by the oldest active read timestamp": 0,
+                    "transaction range of timestamps pinned by the oldest timestamp": {
+                        "$numberLong": "1288490188800"
+                    },
+                    "transaction read timestamp of the oldest active reader": 0,
+                    "transaction rollback to stable currently running": 0,
+                    "transaction walk of concurrent sessions": 26725,
+                    "transactions committed": 661,
+                    "transactions rolled back": 8239,
+                    "update conflicts": 0
+                },
+                "concurrentTransactions": {
+                    "write": {
+                        "out": 0,
+                        "available": 128,
+                        "totalTickets": 128
+                    },
+                    "read": {
+                        "out": 0,
+                        "available": 128,
+                        "totalTickets": 128
+                    }
+                },
+                "snapshot-window-settings": {
+                    "total number of SnapshotTooOld errors": {
+                        "$numberLong": "0"
+                    },
+                    "minimum target snapshot window size in seconds": 300,
+                    "current available snapshot window size in seconds": 300,
+                    "latest majority snapshot timestamp available": "Aug 25 10:09:44:1",
+                    "oldest majority snapshot timestamp available": "Aug 25 10:04:44:1",
+                    "pinned timestamp requests": 0,
+                    "min pinned timestamp": {
+                        "$timestamp": {
+                            "t": -1,
+                            "i": -1
+                        }
+                    }
+                },
+                "oplog": {
+                    "visibility timestamp": {
+                        "$timestamp": {
+                            "t": 1692958184,
+                            "i": 1
+                        }
+                    }
+                }
+            },
+            "mem": {
+                "bits": 64,
+                "resident": 204,
+                "virtual": 3117,
+                "supported": true
+            },
+            "metrics": {
+                "apiVersions": {
+                    "": [
+                        "default"
+                    ],
+                    "mongosh 1.10.3": [
+                        "default"
+                    ],
+                    "mongorestore": [
+                        "default"
+                    ],
+                    "MongoDB Automation Agent v13.2.4.8348 (git: dc291d61da0123fe2f4e178dc8456303c8d1115c)": [
+                        "default"
+                    ],
+                    "OplogFetcher": [
+                        "default"
+                    ],
+                    "MongoDB Monitoring Module v13.2.4.8348 (git: dc291d61da0123fe2f4e178dc8456303c8d1115c)": [
+                        "default"
+                    ]
+                },
+                "aggStageCounters": {
+                    "$_addReshardingResumeId": {
+                        "$numberLong": "0"
+                    },
+                    "$_backupFile": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalAllCollectionStats": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalApplyOplogUpdate": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalBoundedSort": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalChangeStreamAddPostImage": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalChangeStreamAddPreImage": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalChangeStreamCheckInvalidate": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalChangeStreamCheckResumability": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalChangeStreamCheckTopologyChange": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalChangeStreamOplogMatch": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalChangeStreamTransform": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalChangeStreamUnwindTransaction": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalComputeGeoNearDistance": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalConvertBucketIndexStats": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalDensify": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalFindAndModifyImageLookup": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalInhibitOptimization": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalReshardingIterateTransaction": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalReshardingOwnershipMatch": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalSearchIdLookup": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalSearchMongotRemote": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalSetWindowFields": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalSplitPipeline": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalStreamingGroup": {
+                        "$numberLong": "0"
+                    },
+                    "$_internalUnpackBucket": {
+                        "$numberLong": "0"
+                    },
+                    "$_unpackBucket": {
+                        "$numberLong": "0"
+                    },
+                    "$addFields": {
+                        "$numberLong": "0"
+                    },
+                    "$backupCursor": {
+                        "$numberLong": "0"
+                    },
+                    "$backupCursorExtend": {
+                        "$numberLong": "0"
+                    },
+                    "$bucket": {
+                        "$numberLong": "0"
+                    },
+                    "$bucketAuto": {
+                        "$numberLong": "0"
+                    },
+                    "$changeStream": {
+                        "$numberLong": "0"
+                    },
+                    "$changeStreamSplitLargeEvent": {
+                        "$numberLong": "0"
+                    },
+                    "$collStats": {
+                        "$numberLong": "18"
+                    },
+                    "$count": {
+                        "$numberLong": "0"
+                    },
+                    "$currentOp": {
+                        "$numberLong": "0"
+                    },
+                    "$densify": {
+                        "$numberLong": "0"
+                    },
+                    "$documents": {
+                        "$numberLong": "0"
+                    },
+                    "$facet": {
+                        "$numberLong": "0"
+                    },
+                    "$fill": {
+                        "$numberLong": "0"
+                    },
+                    "$geoNear": {
+                        "$numberLong": "0"
+                    },
+                    "$graphLookup": {
+                        "$numberLong": "0"
+                    },
+                    "$group": {
+                        "$numberLong": "22"
+                    },
+                    "$indexStats": {
+                        "$numberLong": "16"
+                    },
+                    "$limit": {
+                        "$numberLong": "0"
+                    },
+                    "$listCachedAndActiveUsers": {
+                        "$numberLong": "0"
+                    },
+                    "$listCatalog": {
+                        "$numberLong": "0"
+                    },
+                    "$listLocalSessions": {
+                        "$numberLong": "0"
+                    },
+                    "$listSearchIndexes": {
+                        "$numberLong": "0"
+                    },
+                    "$listSessions": {
+                        "$numberLong": "0"
+                    },
+                    "$lookup": {
+                        "$numberLong": "0"
+                    },
+                    "$match": {
+                        "$numberLong": "6"
+                    },
+                    "$merge": {
+                        "$numberLong": "0"
+                    },
+                    "$mergeCursors": {
+                        "$numberLong": "0"
+                    },
+                    "$operationMetrics": {
+                        "$numberLong": "0"
+                    },
+                    "$out": {
+                        "$numberLong": "0"
+                    },
+                    "$planCacheStats": {
+                        "$numberLong": "0"
+                    },
+                    "$project": {
+                        "$numberLong": "16"
+                    },
+                    "$queue": {
+                        "$numberLong": "0"
+                    },
+                    "$redact": {
+                        "$numberLong": "0"
+                    },
+                    "$replaceRoot": {
+                        "$numberLong": "0"
+                    },
+                    "$replaceWith": {
+                        "$numberLong": "0"
+                    },
+                    "$sample": {
+                        "$numberLong": "0"
+                    },
+                    "$search": {
+                        "$numberLong": "0"
+                    },
+                    "$searchBeta": {
+                        "$numberLong": "0"
+                    },
+                    "$searchMeta": {
+                        "$numberLong": "0"
+                    },
+                    "$set": {
+                        "$numberLong": "268"
+                    },
+                    "$setVariableFromSubPipeline": {
+                        "$numberLong": "0"
+                    },
+                    "$setWindowFields": {
+                        "$numberLong": "0"
+                    },
+                    "$shardedDataDistribution": {
+                        "$numberLong": "0"
+                    },
+                    "$skip": {
+                        "$numberLong": "0"
+                    },
+                    "$sort": {
+                        "$numberLong": "0"
+                    },
+                    "$sortByCount": {
+                        "$numberLong": "0"
+                    },
+                    "$unionWith": {
+                        "$numberLong": "0"
+                    },
+                    "$unset": {
+                        "$numberLong": "0"
+                    },
+                    "$unwind": {
+                        "$numberLong": "0"
+                    }
+                },
+                "changeStreams": {
+                    "largeEventsFailed": {
+                        "$numberLong": "0"
+                    },
+                    "largeEventsSplit": {
+                        "$numberLong": "0"
+                    }
+                },
+                "commands": {
+                    "<UNKNOWN>": {
+                        "$numberLong": "6"
+                    },
+                    "_addShard": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrAbortReshardCollection": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrAddShard": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrAddShardToZone": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrBalancerCollectionStatus": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrBalancerStart": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrBalancerStatus": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrBalancerStop": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrCleanupReshardCollection": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrClearJumboFlag": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrCollMod": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrCommitChunkMigration": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrCommitChunkSplit": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrCommitChunksMerge": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrCommitMovePrimary": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrCommitReshardCollection": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrConfigureCollectionBalancing": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrCreateDatabase": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrEnsureChunkVersionIsGreaterThan": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrMoveChunk": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrMoveRange": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrRefineCollectionShardKey": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrRemoveChunks": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrRemoveShard": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrRemoveShardFromZone": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrRemoveTags": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrRenameCollectionMetadata": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrRepairShardedCollectionChunksHistory": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrReshardCollection": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrRunRestore": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrSetAllowMigrations": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrSetClusterParameter": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrSetUserWriteBlockMode": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_configsvrUpdateZoneKeyRange": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_flushDatabaseCacheUpdates": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_flushDatabaseCacheUpdatesWithWriteConcern": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_flushReshardingStateChange": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_flushRoutingTableCacheUpdates": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_flushRoutingTableCacheUpdatesWithWriteConcern": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_getAuditConfigGeneration": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_getNextSessionMods": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_getUserCacheGeneration": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_isSelf": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "32"
+                        }
+                    },
+                    "_killOperations": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_mergeAuthzCollections": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_migrateClone": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_recvChunkAbort": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_recvChunkCommit": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_recvChunkReleaseCritSec": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_recvChunkStart": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_recvChunkStatus": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrAbortReshardCollection": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrCleanupReshardCollection": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrCloneCatalogData": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrCollMod": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrCollModParticipant": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrCommitReshardCollection": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrCompactStructuredEncryptionData": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrCreateCollection": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrCreateCollectionParticipant": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrDropCollection": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrDropCollectionIfUUIDNotMatching": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrDropCollectionParticipant": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrDropDatabase": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrDropDatabaseParticipant": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrDropIndexes": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrGetStatsForBalancing": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrJoinMigrations": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrMovePrimary": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrMoveRange": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrParticipantBlock": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrRefineCollectionShardKey": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrRenameCollection": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrRenameCollectionParticipant": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrRenameCollectionParticipantUnblock": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrReshardCollection": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrReshardingOperationTime": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrSetAllowMigrations": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrSetClusterParameter": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_shardsvrSetUserWriteBlockMode": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "_transferMods": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "abortShardSplit": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "abortTransaction": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "aggregate": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "40"
+                        }
+                    },
+                    "appendOplogNote": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "applyOps": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "authenticate": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "autoSplitVector": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "availableQueryOptions": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "buildInfo": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "276"
+                        }
+                    },
+                    "checkShardingIndex": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "cleanupOrphaned": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "cloneCollectionAsCapped": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "clusterAbortTransaction": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "clusterAggregate": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "clusterCommitTransaction": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "clusterDelete": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "clusterFind": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "clusterGetMore": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "clusterInsert": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "clusterUpdate": {
+                        "arrayFilters": {
+                            "$numberLong": "0"
+                        },
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "pipeline": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "collMod": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        },
+                        "validator": {
+                            "failed": {
+                                "$numberLong": "0"
+                            },
+                            "jsonSchema": {
+                                "$numberLong": "0"
+                            },
+                            "total": {
+                                "$numberLong": "0"
+                            }
+                        }
+                    },
+                    "collStats": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "63"
+                        }
+                    },
+                    "commitShardSplit": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "commitTransaction": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "1"
+                        }
+                    },
+                    "compact": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "compactStructuredEncryptionData": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "connPoolStats": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "32"
+                        }
+                    },
+                    "connPoolSync": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "connectionStatus": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "2"
+                        }
+                    },
+                    "convertToCapped": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "coordinateCommitTransaction": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "count": {
+                        "failed": {
+                            "$numberLong": "18"
+                        },
+                        "total": {
+                            "$numberLong": "77"
+                        }
+                    },
+                    "create": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        },
+                        "validator": {
+                            "failed": {
+                                "$numberLong": "0"
+                            },
+                            "jsonSchema": {
+                                "$numberLong": "0"
+                            },
+                            "total": {
+                                "$numberLong": "0"
+                            }
+                        }
+                    },
+                    "createIndexes": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "4"
+                        }
+                    },
+                    "createRole": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "5"
+                        }
+                    },
+                    "createSearchIndexes": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "createUser": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "1"
+                        }
+                    },
+                    "currentOp": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "dataSize": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "dbCheck": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "dbHash": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "dbStats": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "12"
+                        }
+                    },
+                    "delete": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "18"
+                        }
+                    },
+                    "distinct": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "donorAbortMigration": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "donorForgetMigration": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "donorStartMigration": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "driverOIDTest": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "drop": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "dropAllRolesFromDatabase": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "dropAllUsersFromDatabase": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "dropConnections": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "dropDatabase": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "dropIndexes": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "dropRole": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "1"
+                        }
+                    },
+                    "dropSearchIndex": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "dropUser": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "1"
+                        }
+                    },
+                    "endSessions": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "130"
+                        }
+                    },
+                    "explain": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "exportCollection": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "features": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "filemd5": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "find": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "554"
+                        }
+                    },
+                    "findAndModify": {
+                        "arrayFilters": {
+                            "$numberLong": "0"
+                        },
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "pipeline": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "flushRouterConfig": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "forgetShardSplit": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "fsync": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "fsyncUnlock": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "getAuditConfig": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "getClusterParameter": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "getCmdLineOpts": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "193"
+                        }
+                    },
+                    "getDatabaseVersion": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "getDefaultRWConcern": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "59"
+                        }
+                    },
+                    "getDiagnosticData": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "getFreeMonitoringStatus": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "getLastError": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "getLog": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "35"
+                        }
+                    },
+                    "getMore": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "1300"
+                        }
+                    },
+                    "getParameter": {
+                        "failed": {
+                            "$numberLong": "11"
+                        },
+                        "total": {
+                            "$numberLong": "497"
+                        }
+                    },
+                    "getShardMap": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "getShardVersion": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "getnonce": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "grantPrivilegesToRole": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "grantRolesToRole": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "grantRolesToUser": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "hello": {
+                        "failed": {
+                            "$numberLong": "140"
+                        },
+                        "total": {
+                            "$numberLong": "3978"
+                        }
+                    },
+                    "hostInfo": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "37"
+                        }
+                    },
+                    "importCollection": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "insert": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "11"
+                        }
+                    },
+                    "internalRenameIfOptionsAndIndexesMatch": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "invalidateUserCache": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "isMaster": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "5611"
+                        }
+                    },
+                    "killAllSessions": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "killAllSessionsByPattern": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "killCursors": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "killOp": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "killSessions": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "listCollections": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "78"
+                        }
+                    },
+                    "listCommands": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "6"
+                        }
+                    },
+                    "listDatabases": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "10"
+                        }
+                    },
+                    "listIndexes": {
+                        "failed": {
+                            "$numberLong": "2"
+                        },
+                        "total": {
+                            "$numberLong": "29"
+                        }
+                    },
+                    "listSearchIndexes": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "lockInfo": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "logApplicationMessage": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "logRotate": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "1"
+                        }
+                    },
+                    "logout": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "mapReduce": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "mergeChunks": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "ping": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "11096"
+                        }
+                    },
+                    "planCacheClear": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "planCacheClearFilters": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "planCacheListFilters": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "planCacheSetFilter": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "prepareTransaction": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "profile": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "6"
+                        }
+                    },
+                    "reIndex": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "recipientForgetMigration": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "recipientSyncData": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "recipientVoteImportedFiles": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "refreshSessions": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "renameCollection": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "replSetAbortPrimaryCatchUp": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "replSetFreeze": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "replSetGetConfig": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "53"
+                        }
+                    },
+                    "replSetGetRBID": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "replSetGetStatus": {
+                        "failed": {
+                            "$numberLong": "5"
+                        },
+                        "total": {
+                            "$numberLong": "2091"
+                        }
+                    },
+                    "replSetHeartbeat": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "1901"
+                        }
+                    },
+                    "replSetInitiate": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "replSetMaintenance": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "replSetReconfig": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "replSetRequestVotes": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "2"
+                        }
+                    },
+                    "replSetResizeOplog": {
+                        "failed": {
+                            "$numberLong": "8"
+                        },
+                        "total": {
+                            "$numberLong": "8"
+                        }
+                    },
+                    "replSetStepDown": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "replSetStepDownWithForce": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "replSetStepUp": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "replSetSyncFrom": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "replSetUpdatePosition": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "1271"
+                        }
+                    },
+                    "revokePrivilegesFromRole": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "revokeRolesFromRole": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "revokeRolesFromUser": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "rolesInfo": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "rotateCertificates": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "saslContinue": {
+                        "failed": {
+                            "$numberLong": "1"
+                        },
+                        "total": {
+                            "$numberLong": "244"
+                        }
+                    },
+                    "saslStart": {
+                        "failed": {
+                            "$numberLong": "7"
+                        },
+                        "total": {
+                            "$numberLong": "61"
+                        }
+                    },
+                    "serverStatus": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "2303"
+                        }
+                    },
+                    "setAuditConfig": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "setClusterParameter": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "setDefaultRWConcern": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "setFeatureCompatibilityVersion": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "setIndexCommitQuorum": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "setParameter": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "setProfilingFilterGlobally": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "setShardVersion": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "setUserWriteBlockMode": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "shardingState": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "shutdown": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "splitChunk": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "splitVector": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "startRecordingTraffic": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "startSession": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "stopRecordingTraffic": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "top": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "3"
+                        }
+                    },
+                    "update": {
+                        "arrayFilters": {
+                            "$numberLong": "0"
+                        },
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "pipeline": {
+                            "$numberLong": "134"
+                        },
+                        "total": {
+                            "$numberLong": "135"
+                        }
+                    },
+                    "updateRole": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "updateSearchIndex": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "updateUser": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "usersInfo": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "139"
+                        }
+                    },
+                    "validate": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "validateDBMetadata": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "voteCommitImportCollection": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "voteCommitIndexBuild": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "waitForFailPoint": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "whatsmyuri": {
+                        "failed": {
+                            "$numberLong": "0"
+                        },
+                        "total": {
+                            "$numberLong": "0"
+                        }
+                    }
+                },
+                "cursor": {
+                    "moreThanOneBatch": {
+                        "$numberLong": "0"
+                    },
+                    "timedOut": {
+                        "$numberLong": "0"
+                    },
+                    "totalOpened": {
+                        "$numberLong": "42"
+                    },
+                    "lifespan": {
+                        "greaterThanOrEqual10Minutes": {
+                            "$numberLong": "0"
+                        },
+                        "lessThan10Minutes": {
+                            "$numberLong": "0"
+                        },
+                        "lessThan15Seconds": {
+                            "$numberLong": "0"
+                        },
+                        "lessThan1Minute": {
+                            "$numberLong": "0"
+                        },
+                        "lessThan1Second": {
+                            "$numberLong": "40"
+                        },
+                        "lessThan30Seconds": {
+                            "$numberLong": "0"
+                        },
+                        "lessThan5Seconds": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "open": {
+                        "noTimeout": {
+                            "$numberLong": "0"
+                        },
+                        "pinned": {
+                            "$numberLong": "2"
+                        },
+                        "total": {
+                            "$numberLong": "2"
+                        }
+                    }
+                },
+                "document": {
+                    "deleted": {
+                        "$numberLong": "5"
+                    },
+                    "inserted": {
+                        "$numberLong": "11"
+                    },
+                    "returned": {
+                        "$numberLong": "1485"
+                    },
+                    "updated": {
+                        "$numberLong": "209"
+                    }
+                },
+                "dotsAndDollarsFields": {
+                    "inserts": {
+                        "$numberLong": "0"
+                    },
+                    "updates": {
+                        "$numberLong": "0"
+                    }
+                },
+                "getLastError": {
+                    "wtime": {
+                        "num": 47,
+                        "totalMillis": 1817
+                    },
+                    "wtimeouts": {
+                        "$numberLong": "0"
+                    },
+                    "default": {
+                        "unsatisfiable": {
+                            "$numberLong": "0"
+                        },
+                        "wtimeouts": {
+                            "$numberLong": "0"
+                        }
+                    }
+                },
+                "mongos": {
+                    "cursor": {
+                        "moreThanOneBatch": {
+                            "$numberLong": "0"
+                        },
+                        "totalOpened": {
+                            "$numberLong": "0"
+                        }
+                    }
+                },
+                "operation": {
+                    "scanAndOrder": {
+                        "$numberLong": "5"
+                    },
+                    "temporarilyUnavailableErrors": {
+                        "$numberLong": "0"
+                    },
+                    "temporarilyUnavailableErrorsConvertedToWriteConflict": {
+                        "$numberLong": "0"
+                    },
+                    "temporarilyUnavailableErrorsEscaped": {
+                        "$numberLong": "0"
+                    },
+                    "transactionTooLargeForCacheErrors": {
+                        "$numberLong": "0"
+                    },
+                    "transactionTooLargeForCacheErrorsConvertedToWriteConflict": {
+                        "$numberLong": "0"
+                    },
+                    "writeConflicts": {
+                        "$numberLong": "0"
+                    }
+                },
+                "operatorCounters": {
+                    "expressions": {
+                        "$_internalFindAllValuesAtPath": {
+                            "$numberLong": "0"
+                        },
+                        "$_internalFleEq": {
+                            "$numberLong": "0"
+                        },
+                        "$_internalJsEmit": {
+                            "$numberLong": "0"
+                        },
+                        "$abs": {
+                            "$numberLong": "0"
+                        },
+                        "$acos": {
+                            "$numberLong": "0"
+                        },
+                        "$acosh": {
+                            "$numberLong": "0"
+                        },
+                        "$add": {
+                            "$numberLong": "0"
+                        },
+                        "$allElementsTrue": {
+                            "$numberLong": "0"
+                        },
+                        "$and": {
+                            "$numberLong": "0"
+                        },
+                        "$anyElementTrue": {
+                            "$numberLong": "0"
+                        },
+                        "$arrayElemAt": {
+                            "$numberLong": "0"
+                        },
+                        "$arrayToObject": {
+                            "$numberLong": "0"
+                        },
+                        "$asin": {
+                            "$numberLong": "0"
+                        },
+                        "$asinh": {
+                            "$numberLong": "0"
+                        },
+                        "$atan": {
+                            "$numberLong": "0"
+                        },
+                        "$atan2": {
+                            "$numberLong": "0"
+                        },
+                        "$atanh": {
+                            "$numberLong": "0"
+                        },
+                        "$avg": {
+                            "$numberLong": "0"
+                        },
+                        "$binarySize": {
+                            "$numberLong": "0"
+                        },
+                        "$bsonSize": {
+                            "$numberLong": "0"
+                        },
+                        "$ceil": {
+                            "$numberLong": "0"
+                        },
+                        "$cmp": {
+                            "$numberLong": "0"
+                        },
+                        "$concat": {
+                            "$numberLong": "0"
+                        },
+                        "$concatArrays": {
+                            "$numberLong": "0"
+                        },
+                        "$cond": {
+                            "$numberLong": "0"
+                        },
+                        "$const": {
+                            "$numberLong": "0"
+                        },
+                        "$convert": {
+                            "$numberLong": "0"
+                        },
+                        "$cos": {
+                            "$numberLong": "0"
+                        },
+                        "$cosh": {
+                            "$numberLong": "0"
+                        },
+                        "$dateAdd": {
+                            "$numberLong": "0"
+                        },
+                        "$dateDiff": {
+                            "$numberLong": "0"
+                        },
+                        "$dateFromParts": {
+                            "$numberLong": "0"
+                        },
+                        "$dateFromString": {
+                            "$numberLong": "0"
+                        },
+                        "$dateSubtract": {
+                            "$numberLong": "0"
+                        },
+                        "$dateToParts": {
+                            "$numberLong": "0"
+                        },
+                        "$dateToString": {
+                            "$numberLong": "0"
+                        },
+                        "$dateTrunc": {
+                            "$numberLong": "0"
+                        },
+                        "$dayOfMonth": {
+                            "$numberLong": "0"
+                        },
+                        "$dayOfWeek": {
+                            "$numberLong": "0"
+                        },
+                        "$dayOfYear": {
+                            "$numberLong": "0"
+                        },
+                        "$degreesToRadians": {
+                            "$numberLong": "0"
+                        },
+                        "$divide": {
+                            "$numberLong": "0"
+                        },
+                        "$eq": {
+                            "$numberLong": "0"
+                        },
+                        "$exp": {
+                            "$numberLong": "0"
+                        },
+                        "$filter": {
+                            "$numberLong": "0"
+                        },
+                        "$first": {
+                            "$numberLong": "0"
+                        },
+                        "$firstN": {
+                            "$numberLong": "0"
+                        },
+                        "$floor": {
+                            "$numberLong": "0"
+                        },
+                        "$function": {
+                            "$numberLong": "0"
+                        },
+                        "$getField": {
+                            "$numberLong": "0"
+                        },
+                        "$gt": {
+                            "$numberLong": "0"
+                        },
+                        "$gte": {
+                            "$numberLong": "0"
+                        },
+                        "$hour": {
+                            "$numberLong": "0"
+                        },
+                        "$ifNull": {
+                            "$numberLong": "0"
+                        },
+                        "$in": {
+                            "$numberLong": "0"
+                        },
+                        "$indexOfArray": {
+                            "$numberLong": "0"
+                        },
+                        "$indexOfBytes": {
+                            "$numberLong": "0"
+                        },
+                        "$indexOfCP": {
+                            "$numberLong": "0"
+                        },
+                        "$isArray": {
+                            "$numberLong": "0"
+                        },
+                        "$isNumber": {
+                            "$numberLong": "0"
+                        },
+                        "$isoDayOfWeek": {
+                            "$numberLong": "0"
+                        },
+                        "$isoWeek": {
+                            "$numberLong": "0"
+                        },
+                        "$isoWeekYear": {
+                            "$numberLong": "0"
+                        },
+                        "$last": {
+                            "$numberLong": "0"
+                        },
+                        "$lastN": {
+                            "$numberLong": "0"
+                        },
+                        "$let": {
+                            "$numberLong": "0"
+                        },
+                        "$literal": {
+                            "$numberLong": "0"
+                        },
+                        "$ln": {
+                            "$numberLong": "0"
+                        },
+                        "$log": {
+                            "$numberLong": "0"
+                        },
+                        "$log10": {
+                            "$numberLong": "0"
+                        },
+                        "$lt": {
+                            "$numberLong": "0"
+                        },
+                        "$lte": {
+                            "$numberLong": "0"
+                        },
+                        "$ltrim": {
+                            "$numberLong": "0"
+                        },
+                        "$map": {
+                            "$numberLong": "0"
+                        },
+                        "$max": {
+                            "$numberLong": "0"
+                        },
+                        "$maxN": {
+                            "$numberLong": "0"
+                        },
+                        "$mergeObjects": {
+                            "$numberLong": "0"
+                        },
+                        "$meta": {
+                            "$numberLong": "0"
+                        },
+                        "$millisecond": {
+                            "$numberLong": "0"
+                        },
+                        "$min": {
+                            "$numberLong": "0"
+                        },
+                        "$minN": {
+                            "$numberLong": "0"
+                        },
+                        "$minute": {
+                            "$numberLong": "0"
+                        },
+                        "$mod": {
+                            "$numberLong": "0"
+                        },
+                        "$month": {
+                            "$numberLong": "0"
+                        },
+                        "$multiply": {
+                            "$numberLong": "0"
+                        },
+                        "$ne": {
+                            "$numberLong": "0"
+                        },
+                        "$not": {
+                            "$numberLong": "0"
+                        },
+                        "$objectToArray": {
+                            "$numberLong": "0"
+                        },
+                        "$or": {
+                            "$numberLong": "0"
+                        },
+                        "$pow": {
+                            "$numberLong": "0"
+                        },
+                        "$radiansToDegrees": {
+                            "$numberLong": "0"
+                        },
+                        "$rand": {
+                            "$numberLong": "0"
+                        },
+                        "$range": {
+                            "$numberLong": "0"
+                        },
+                        "$reduce": {
+                            "$numberLong": "0"
+                        },
+                        "$regexFind": {
+                            "$numberLong": "0"
+                        },
+                        "$regexFindAll": {
+                            "$numberLong": "0"
+                        },
+                        "$regexMatch": {
+                            "$numberLong": "0"
+                        },
+                        "$replaceAll": {
+                            "$numberLong": "0"
+                        },
+                        "$replaceOne": {
+                            "$numberLong": "0"
+                        },
+                        "$reverseArray": {
+                            "$numberLong": "0"
+                        },
+                        "$round": {
+                            "$numberLong": "0"
+                        },
+                        "$rtrim": {
+                            "$numberLong": "0"
+                        },
+                        "$second": {
+                            "$numberLong": "0"
+                        },
+                        "$setDifference": {
+                            "$numberLong": "0"
+                        },
+                        "$setEquals": {
+                            "$numberLong": "0"
+                        },
+                        "$setField": {
+                            "$numberLong": "0"
+                        },
+                        "$setIntersection": {
+                            "$numberLong": "0"
+                        },
+                        "$setIsSubset": {
+                            "$numberLong": "0"
+                        },
+                        "$setUnion": {
+                            "$numberLong": "0"
+                        },
+                        "$sin": {
+                            "$numberLong": "0"
+                        },
+                        "$sinh": {
+                            "$numberLong": "0"
+                        },
+                        "$size": {
+                            "$numberLong": "0"
+                        },
+                        "$slice": {
+                            "$numberLong": "0"
+                        },
+                        "$sortArray": {
+                            "$numberLong": "0"
+                        },
+                        "$split": {
+                            "$numberLong": "0"
+                        },
+                        "$sqrt": {
+                            "$numberLong": "0"
+                        },
+                        "$stdDevPop": {
+                            "$numberLong": "0"
+                        },
+                        "$stdDevSamp": {
+                            "$numberLong": "0"
+                        },
+                        "$strLenBytes": {
+                            "$numberLong": "0"
+                        },
+                        "$strLenCP": {
+                            "$numberLong": "0"
+                        },
+                        "$strcasecmp": {
+                            "$numberLong": "0"
+                        },
+                        "$substr": {
+                            "$numberLong": "0"
+                        },
+                        "$substrBytes": {
+                            "$numberLong": "0"
+                        },
+                        "$substrCP": {
+                            "$numberLong": "0"
+                        },
+                        "$subtract": {
+                            "$numberLong": "0"
+                        },
+                        "$sum": {
+                            "$numberLong": "0"
+                        },
+                        "$switch": {
+                            "$numberLong": "0"
+                        },
+                        "$tan": {
+                            "$numberLong": "0"
+                        },
+                        "$tanh": {
+                            "$numberLong": "0"
+                        },
+                        "$toBool": {
+                            "$numberLong": "0"
+                        },
+                        "$toDate": {
+                            "$numberLong": "0"
+                        },
+                        "$toDecimal": {
+                            "$numberLong": "0"
+                        },
+                        "$toDouble": {
+                            "$numberLong": "0"
+                        },
+                        "$toHashedIndexKey": {
+                            "$numberLong": "0"
+                        },
+                        "$toInt": {
+                            "$numberLong": "0"
+                        },
+                        "$toLong": {
+                            "$numberLong": "0"
+                        },
+                        "$toLower": {
+                            "$numberLong": "0"
+                        },
+                        "$toObjectId": {
+                            "$numberLong": "0"
+                        },
+                        "$toString": {
+                            "$numberLong": "0"
+                        },
+                        "$toUpper": {
+                            "$numberLong": "0"
+                        },
+                        "$trim": {
+                            "$numberLong": "0"
+                        },
+                        "$trunc": {
+                            "$numberLong": "0"
+                        },
+                        "$tsIncrement": {
+                            "$numberLong": "0"
+                        },
+                        "$tsSecond": {
+                            "$numberLong": "0"
+                        },
+                        "$type": {
+                            "$numberLong": "0"
+                        },
+                        "$unsetField": {
+                            "$numberLong": "0"
+                        },
+                        "$week": {
+                            "$numberLong": "0"
+                        },
+                        "$year": {
+                            "$numberLong": "0"
+                        },
+                        "$zip": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "groupAccumulators": {
+                        "$_internalJsReduce": {
+                            "$numberLong": "0"
+                        },
+                        "$accumulator": {
+                            "$numberLong": "0"
+                        },
+                        "$addToSet": {
+                            "$numberLong": "0"
+                        },
+                        "$avg": {
+                            "$numberLong": "0"
+                        },
+                        "$bottom": {
+                            "$numberLong": "0"
+                        },
+                        "$bottomN": {
+                            "$numberLong": "0"
+                        },
+                        "$count": {
+                            "$numberLong": "0"
+                        },
+                        "$first": {
+                            "$numberLong": "0"
+                        },
+                        "$firstN": {
+                            "$numberLong": "0"
+                        },
+                        "$last": {
+                            "$numberLong": "0"
+                        },
+                        "$lastN": {
+                            "$numberLong": "0"
+                        },
+                        "$max": {
+                            "$numberLong": "0"
+                        },
+                        "$maxN": {
+                            "$numberLong": "0"
+                        },
+                        "$mergeObjects": {
+                            "$numberLong": "0"
+                        },
+                        "$min": {
+                            "$numberLong": "0"
+                        },
+                        "$minN": {
+                            "$numberLong": "0"
+                        },
+                        "$push": {
+                            "$numberLong": "16"
+                        },
+                        "$stdDevPop": {
+                            "$numberLong": "0"
+                        },
+                        "$stdDevSamp": {
+                            "$numberLong": "0"
+                        },
+                        "$sum": {
+                            "$numberLong": "6"
+                        },
+                        "$top": {
+                            "$numberLong": "0"
+                        },
+                        "$topN": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "match": {
+                        "$all": {
+                            "$numberLong": "0"
+                        },
+                        "$alwaysFalse": {
+                            "$numberLong": "0"
+                        },
+                        "$alwaysTrue": {
+                            "$numberLong": "0"
+                        },
+                        "$and": {
+                            "$numberLong": "0"
+                        },
+                        "$bitsAllClear": {
+                            "$numberLong": "0"
+                        },
+                        "$bitsAllSet": {
+                            "$numberLong": "0"
+                        },
+                        "$bitsAnyClear": {
+                            "$numberLong": "0"
+                        },
+                        "$bitsAnySet": {
+                            "$numberLong": "0"
+                        },
+                        "$comment": {
+                            "$numberLong": "0"
+                        },
+                        "$elemMatch": {
+                            "$numberLong": "2"
+                        },
+                        "$eq": {
+                            "$numberLong": "113"
+                        },
+                        "$exists": {
+                            "$numberLong": "0"
+                        },
+                        "$expr": {
+                            "$numberLong": "0"
+                        },
+                        "$geoIntersects": {
+                            "$numberLong": "0"
+                        },
+                        "$geoWithin": {
+                            "$numberLong": "0"
+                        },
+                        "$gt": {
+                            "$numberLong": "12"
+                        },
+                        "$gte": {
+                            "$numberLong": "2"
+                        },
+                        "$in": {
+                            "$numberLong": "0"
+                        },
+                        "$jsonSchema": {
+                            "$numberLong": "0"
+                        },
+                        "$lt": {
+                            "$numberLong": "6"
+                        },
+                        "$lte": {
+                            "$numberLong": "0"
+                        },
+                        "$mod": {
+                            "$numberLong": "0"
+                        },
+                        "$ne": {
+                            "$numberLong": "18"
+                        },
+                        "$near": {
+                            "$numberLong": "0"
+                        },
+                        "$nearSphere": {
+                            "$numberLong": "0"
+                        },
+                        "$nin": {
+                            "$numberLong": "0"
+                        },
+                        "$nor": {
+                            "$numberLong": "0"
+                        },
+                        "$not": {
+                            "$numberLong": "0"
+                        },
+                        "$or": {
+                            "$numberLong": "0"
+                        },
+                        "$regex": {
+                            "$numberLong": "0"
+                        },
+                        "$sampleRate": {
+                            "$numberLong": "0"
+                        },
+                        "$size": {
+                            "$numberLong": "0"
+                        },
+                        "$text": {
+                            "$numberLong": "0"
+                        },
+                        "$type": {
+                            "$numberLong": "0"
+                        },
+                        "$where": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "windowAccumulators": {
+                        "$addToSet": {
+                            "$numberLong": "0"
+                        },
+                        "$avg": {
+                            "$numberLong": "0"
+                        },
+                        "$bottom": {
+                            "$numberLong": "0"
+                        },
+                        "$bottomN": {
+                            "$numberLong": "0"
+                        },
+                        "$count": {
+                            "$numberLong": "0"
+                        },
+                        "$covariancePop": {
+                            "$numberLong": "0"
+                        },
+                        "$covarianceSamp": {
+                            "$numberLong": "0"
+                        },
+                        "$denseRank": {
+                            "$numberLong": "0"
+                        },
+                        "$derivative": {
+                            "$numberLong": "0"
+                        },
+                        "$documentNumber": {
+                            "$numberLong": "0"
+                        },
+                        "$expMovingAvg": {
+                            "$numberLong": "0"
+                        },
+                        "$first": {
+                            "$numberLong": "0"
+                        },
+                        "$firstN": {
+                            "$numberLong": "0"
+                        },
+                        "$integral": {
+                            "$numberLong": "0"
+                        },
+                        "$last": {
+                            "$numberLong": "0"
+                        },
+                        "$lastN": {
+                            "$numberLong": "0"
+                        },
+                        "$linearFill": {
+                            "$numberLong": "0"
+                        },
+                        "$locf": {
+                            "$numberLong": "0"
+                        },
+                        "$max": {
+                            "$numberLong": "0"
+                        },
+                        "$maxN": {
+                            "$numberLong": "0"
+                        },
+                        "$min": {
+                            "$numberLong": "0"
+                        },
+                        "$minN": {
+                            "$numberLong": "0"
+                        },
+                        "$push": {
+                            "$numberLong": "0"
+                        },
+                        "$rank": {
+                            "$numberLong": "0"
+                        },
+                        "$shift": {
+                            "$numberLong": "0"
+                        },
+                        "$stdDevPop": {
+                            "$numberLong": "0"
+                        },
+                        "$stdDevSamp": {
+                            "$numberLong": "0"
+                        },
+                        "$sum": {
+                            "$numberLong": "0"
+                        },
+                        "$top": {
+                            "$numberLong": "0"
+                        },
+                        "$topN": {
+                            "$numberLong": "0"
+                        }
+                    }
+                },
+                "query": {
+                    "allowDiskUseFalse": {
+                        "$numberLong": "0"
+                    },
+                    "deleteManyCount": {
+                        "$numberLong": "413"
+                    },
+                    "planCacheTotalSizeEstimateBytes": {
+                        "$numberLong": "0"
+                    },
+                    "updateDeleteManyDocumentsMaxCount": {
+                        "$numberLong": "1"
+                    },
+                    "updateDeleteManyDocumentsTotalCount": {
+                        "$numberLong": "6"
+                    },
+                    "updateDeleteManyDurationMaxMs": {
+                        "$numberLong": "0"
+                    },
+                    "updateDeleteManyDurationTotalMs": {
+                        "$numberLong": "10"
+                    },
+                    "updateManyCount": {
+                        "$numberLong": "2"
+                    },
+                    "updateOneOpStyleBroadcastWithExactIDCount": {
+                        "$numberLong": "0"
+                    },
+                    "multiPlanner": {
+                        "classicCount": {
+                            "$numberLong": "0"
+                        },
+                        "classicMicros": {
+                            "$numberLong": "0"
+                        },
+                        "classicWorks": {
+                            "$numberLong": "0"
+                        },
+                        "sbeCount": {
+                            "$numberLong": "0"
+                        },
+                        "sbeMicros": {
+                            "$numberLong": "0"
+                        },
+                        "sbeNumReads": {
+                            "$numberLong": "0"
+                        },
+                        "histograms": {
+                            "classicMicros": [
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "0"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "1024"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "4096"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "16384"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "65536"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "262144"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "1048576"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "4194304"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "16777216"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "67108864"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "268435456"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "1073741824"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                }
+                            ],
+                            "classicNumPlans": [
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "0"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "2"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "4"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "8"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "16"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "32"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                }
+                            ],
+                            "classicWorks": [
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "0"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "128"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "256"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "512"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "1024"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "2048"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "4096"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "8192"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "16384"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "32768"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                }
+                            ],
+                            "sbeMicros": [
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "0"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "1024"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "4096"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "16384"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "65536"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "262144"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "1048576"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "4194304"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "16777216"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "67108864"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "268435456"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "1073741824"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                }
+                            ],
+                            "sbeNumPlans": [
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "0"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "2"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "4"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "8"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "16"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "32"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                }
+                            ],
+                            "sbeNumReads": [
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "0"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "128"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "256"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "512"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "1024"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "2048"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "4096"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "8192"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "16384"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                },
+                                {
+                                    "lowerBound": {
+                                        "$numberLong": "32768"
+                                    },
+                                    "count": {
+                                        "$numberLong": "0"
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "queryFramework": {
+                        "aggregate": {
+                            "classicHybrid": {
+                                "$numberLong": "6"
+                            },
+                            "classicOnly": {
+                                "$numberLong": "0"
+                            },
+                            "cqf": {
+                                "$numberLong": "0"
+                            },
+                            "sbeHybrid": {
+                                "$numberLong": "0"
+                            },
+                            "sbeOnly": {
+                                "$numberLong": "0"
+                            }
+                        },
+                        "find": {
+                            "classic": {
+                                "$numberLong": "554"
+                            },
+                            "cqf": {
+                                "$numberLong": "0"
+                            },
+                            "sbe": {
+                                "$numberLong": "0"
+                            }
+                        }
+                    }
+                },
+                "queryExecutor": {
+                    "scanned": {
+                        "$numberLong": "111"
+                    },
+                    "scannedObjects": {
+                        "$numberLong": "1691"
+                    },
+                    "collectionScans": {
+                        "nonTailable": {
+                            "$numberLong": "544"
+                        },
+                        "total": {
+                            "$numberLong": "546"
+                        }
+                    }
+                },
+                "repl": {
+                    "executor": {
+                        "pool": {
+                            "inProgressCount": 0
+                        },
+                        "queues": {
+                            "networkInProgress": 0,
+                            "sleepers": 3
+                        },
+                        "unsignaledEvents": 0,
+                        "shuttingDown": false,
+                        "networkInterface": "DEPRECATED: getDiagnosticString is deprecated in NetworkInterfaceTL"
+                    },
+                    "apply": {
+                        "attemptsToBecomeSecondary": {
+                            "$numberLong": "1"
+                        },
+                        "batchSize": {
+                            "$numberLong": "7"
+                        },
+                        "batches": {
+                            "num": 7,
+                            "totalMillis": 64
+                        },
+                        "ops": {
+                            "$numberLong": "7"
+                        }
+                    },
+                    "buffer": {
+                        "count": {
+                            "$numberLong": "0"
+                        },
+                        "maxSizeBytes": {
+                            "$numberLong": "268435456"
+                        },
+                        "sizeBytes": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "initialSync": {
+                        "completed": {
+                            "$numberLong": "1"
+                        },
+                        "failedAttempts": {
+                            "$numberLong": "1"
+                        },
+                        "failures": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "network": {
+                        "bytes": {
+                            "$numberLong": "2054"
+                        },
+                        "getmores": {
+                            "num": 5,
+                            "totalMillis": 5015,
+                            "numEmptyBatches": {
+                                "$numberLong": "3"
+                            }
+                        },
+                        "notPrimaryLegacyUnacknowledgedWrites": {
+                            "$numberLong": "0"
+                        },
+                        "notPrimaryUnacknowledgedWrites": {
+                            "$numberLong": "0"
+                        },
+                        "oplogGetMoresProcessed": {
+                            "num": 1298,
+                            "totalMillis": 0
+                        },
+                        "ops": {
+                            "$numberLong": "9"
+                        },
+                        "readersCreated": {
+                            "$numberLong": "3"
+                        },
+                        "replSetUpdatePosition": {
+                            "num": {
+                                "$numberLong": "18"
+                            }
+                        }
+                    },
+                    "reconfig": {
+                        "numAutoReconfigsForRemovalOfNewlyAddedFields": {
+                            "$numberLong": "0"
+                        }
+                    },
+                    "stateTransition": {
+                        "lastStateTransition": "stepUp",
+                        "userOperationsKilled": {
+                            "$numberLong": "0"
+                        },
+                        "userOperationsRunning": {
+                            "$numberLong": "7"
+                        }
+                    },
+                    "syncSource": {
+                        "numSelections": {
+                            "$numberLong": "2"
+                        },
+                        "numSyncSourceChangesDueToSignificantlyCloserNode": {
+                            "$numberLong": "0"
+                        },
+                        "numTimesChoseDifferent": {
+                            "$numberLong": "1"
+                        },
+                        "numTimesChoseSame": {
+                            "$numberLong": "1"
+                        },
+                        "numTimesCouldNotFind": {
+                            "$numberLong": "0"
+                        }
+                    }
+                },
+                "ttl": {
+                    "deletedDocuments": {
+                        "$numberLong": "0"
+                    },
+                    "passes": {
+                        "$numberLong": "30"
+                    }
+                }
+            },
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            }
+        },
+        "section": "server_info",
+        "subsection": "server_status_info",
+        "ts": {
+            "start": {
+                "$date": 1692958188089
+            },
+            "end": {
+                "$date": 1692958188337
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.hostInfo();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "system": {
+                "currentTime": {
+                    "$date": 1692958188719
+                },
+                "hostname": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+                "cpuAddrSize": 64,
+                "memSizeMB": {
+                    "$numberLong": "1851"
+                },
+                "memLimitMB": {
+                    "$numberLong": "1851"
+                },
+                "numCores": 2,
+                "numPhysicalCores": 1,
+                "numCpuSockets": 1,
+                "cpuArch": "aarch64",
+                "numaEnabled": false,
+                "numNumaNodes": 1
+            },
+            "os": {
+                "type": "Linux",
+                "name": "Amazon Linux release 2 (Karoo)",
+                "version": "Kernel 5.10.186-179.751.amzn2.aarch64"
+            },
+            "extra": {
+                "extra": {
+                    "versionString": "Linux version 5.10.186-179.751.amzn2.aarch64 (mockbuild@ip-10-0-54-102) (gcc10-gcc (GCC) 10.4.1 20221124 (Red Hat 10.4.0-1), GNU ld version 2.35.2-9.amzn2.0.1) #1 SMP Tue Aug 1 20:51:46 UTC 2023",
+                    "libcVersion": "2.26",
+                    "kernelVersion": "5.10.186-179.751.amzn2.aarch64",
+                    "cpuFrequencyMHz": {
+                        "$date": 1692958193915
+                    },
+                    "cpuFeatures": {
+                        "$date": 1692958193915
+                    },
+                    "pageSize": {
+                        "$numberLong": "4096"
+                    },
+                    "numPages": 473934,
+                    "maxOpenFiles": 153850,
+                    "mountInfo": [
+                        {
+                            "mountId": 23,
+                            "parentId": 45,
+                            "major": 0,
+                            "minor": 22,
+                            "root": "/",
+                            "mountPoint": "/sys",
+                            "options": "rw,nosuid,nodev,noexec,relatime",
+                            "fields": "shared:6",
+                            "type": "sysfs",
+                            "source": "sysfs",
+                            "superOpt": "rw,seclabel"
+                        },
+                        {
+                            "mountId": 24,
+                            "parentId": 45,
+                            "major": 0,
+                            "minor": 23,
+                            "root": "/",
+                            "mountPoint": "/proc",
+                            "options": "rw,nosuid,nodev,noexec,relatime",
+                            "fields": "shared:5",
+                            "type": "proc",
+                            "source": "proc",
+                            "superOpt": "rw"
+                        },
+                        {
+                            "mountId": 25,
+                            "parentId": 45,
+                            "major": 0,
+                            "minor": 5,
+                            "root": "/",
+                            "mountPoint": "/dev",
+                            "options": "rw,nosuid",
+                            "fields": "shared:2",
+                            "type": "devtmpfs",
+                            "source": "devtmpfs",
+                            "superOpt": "rw,seclabel,size=907928k,nr_inodes=226982,mode=755"
+                        },
+                        {
+                            "mountId": 26,
+                            "parentId": 23,
+                            "major": 0,
+                            "minor": 6,
+                            "root": "/",
+                            "mountPoint": "/sys/kernel/security",
+                            "options": "rw,nosuid,nodev,noexec,relatime",
+                            "fields": "shared:7",
+                            "type": "securityfs",
+                            "source": "securityfs",
+                            "superOpt": "rw"
+                        },
+                        {
+                            "mountId": 27,
+                            "parentId": 25,
+                            "major": 0,
+                            "minor": 24,
+                            "root": "/",
+                            "mountPoint": "/dev/shm",
+                            "options": "rw,nosuid,nodev",
+                            "fields": "shared:3",
+                            "type": "tmpfs",
+                            "source": "tmpfs",
+                            "superOpt": "rw,seclabel"
+                        },
+                        {
+                            "mountId": 28,
+                            "parentId": 25,
+                            "major": 0,
+                            "minor": 25,
+                            "root": "/",
+                            "mountPoint": "/dev/pts",
+                            "options": "rw,nosuid,noexec,relatime",
+                            "fields": "shared:4",
+                            "type": "devpts",
+                            "source": "devpts",
+                            "superOpt": "rw,seclabel,gid=5,mode=620,ptmxmode=000"
+                        },
+                        {
+                            "mountId": 29,
+                            "parentId": 45,
+                            "major": 0,
+                            "minor": 26,
+                            "root": "/",
+                            "mountPoint": "/run",
+                            "options": "rw,nosuid,nodev",
+                            "fields": "shared:24",
+                            "type": "tmpfs",
+                            "source": "tmpfs",
+                            "superOpt": "rw,seclabel,mode=755"
+                        },
+                        {
+                            "mountId": 30,
+                            "parentId": 23,
+                            "major": 0,
+                            "minor": 27,
+                            "root": "/",
+                            "mountPoint": "/sys/fs/cgroup",
+                            "options": "ro,nosuid,nodev,noexec",
+                            "fields": "shared:8",
+                            "type": "tmpfs",
+                            "source": "tmpfs",
+                            "superOpt": "ro,seclabel,mode=755"
+                        },
+                        {
+                            "mountId": 31,
+                            "parentId": 30,
+                            "major": 0,
+                            "minor": 28,
+                            "root": "/",
+                            "mountPoint": "/sys/fs/cgroup/systemd",
+                            "options": "rw,nosuid,nodev,noexec,relatime",
+                            "fields": "shared:9",
+                            "type": "cgroup",
+                            "source": "cgroup",
+                            "superOpt": "rw,seclabel,xattr,release_agent=/usr/lib/systemd/systemd-cgroups-agent,name=systemd"
+                        },
+                        {
+                            "mountId": 32,
+                            "parentId": 23,
+                            "major": 0,
+                            "minor": 29,
+                            "root": "/",
+                            "mountPoint": "/sys/fs/pstore",
+                            "options": "rw,nosuid,nodev,noexec,relatime",
+                            "fields": "shared:20",
+                            "type": "pstore",
+                            "source": "pstore",
+                            "superOpt": "rw,seclabel"
+                        },
+                        {
+                            "mountId": 33,
+                            "parentId": 23,
+                            "major": 0,
+                            "minor": 30,
+                            "root": "/",
+                            "mountPoint": "/sys/firmware/efi/efivars",
+                            "options": "rw,nosuid,nodev,noexec,relatime",
+                            "fields": "shared:21",
+                            "type": "efivarfs",
+                            "source": "efivarfs",
+                            "superOpt": "rw"
+                        },
+                        {
+                            "mountId": 34,
+                            "parentId": 30,
+                            "major": 0,
+                            "minor": 31,
+                            "root": "/",
+                            "mountPoint": "/sys/fs/cgroup/devices",
+                            "options": "rw,nosuid,nodev,noexec,relatime",
+                            "fields": "shared:10",
+                            "type": "cgroup",
+                            "source": "cgroup",
+                            "superOpt": "rw,seclabel,devices"
+                        },
+                        {
+                            "mountId": 35,
+                            "parentId": 30,
+                            "major": 0,
+                            "minor": 32,
+                            "root": "/",
+                            "mountPoint": "/sys/fs/cgroup/hugetlb",
+                            "options": "rw,nosuid,nodev,noexec,relatime",
+                            "fields": "shared:11",
+                            "type": "cgroup",
+                            "source": "cgroup",
+                            "superOpt": "rw,seclabel,hugetlb"
+                        },
+                        {
+                            "mountId": 36,
+                            "parentId": 30,
+                            "major": 0,
+                            "minor": 33,
+                            "root": "/",
+                            "mountPoint": "/sys/fs/cgroup/memory",
+                            "options": "rw,nosuid,nodev,noexec,relatime",
+                            "fields": "shared:12",
+                            "type": "cgroup",
+                            "source": "cgroup",
+                            "superOpt": "rw,seclabel,memory"
+                        },
+                        {
+                            "mountId": 37,
+                            "parentId": 30,
+                            "major": 0,
+                            "minor": 34,
+                            "root": "/",
+                            "mountPoint": "/sys/fs/cgroup/net_cls,net_prio",
+                            "options": "rw,nosuid,nodev,noexec,relatime",
+                            "fields": "shared:13",
+                            "type": "cgroup",
+                            "source": "cgroup",
+                            "superOpt": "rw,seclabel,net_cls,net_prio"
+                        },
+                        {
+                            "mountId": 38,
+                            "parentId": 30,
+                            "major": 0,
+                            "minor": 35,
+                            "root": "/",
+                            "mountPoint": "/sys/fs/cgroup/cpuset",
+                            "options": "rw,nosuid,nodev,noexec,relatime",
+                            "fields": "shared:14",
+                            "type": "cgroup",
+                            "source": "cgroup",
+                            "superOpt": "rw,seclabel,cpuset"
+                        },
+                        {
+                            "mountId": 39,
+                            "parentId": 30,
+                            "major": 0,
+                            "minor": 36,
+                            "root": "/",
+                            "mountPoint": "/sys/fs/cgroup/perf_event",
+                            "options": "rw,nosuid,nodev,noexec,relatime",
+                            "fields": "shared:15",
+                            "type": "cgroup",
+                            "source": "cgroup",
+                            "superOpt": "rw,seclabel,perf_event"
+                        },
+                        {
+                            "mountId": 40,
+                            "parentId": 30,
+                            "major": 0,
+                            "minor": 37,
+                            "root": "/",
+                            "mountPoint": "/sys/fs/cgroup/freezer",
+                            "options": "rw,nosuid,nodev,noexec,relatime",
+                            "fields": "shared:16",
+                            "type": "cgroup",
+                            "source": "cgroup",
+                            "superOpt": "rw,seclabel,freezer"
+                        },
+                        {
+                            "mountId": 41,
+                            "parentId": 30,
+                            "major": 0,
+                            "minor": 38,
+                            "root": "/",
+                            "mountPoint": "/sys/fs/cgroup/pids",
+                            "options": "rw,nosuid,nodev,noexec,relatime",
+                            "fields": "shared:17",
+                            "type": "cgroup",
+                            "source": "cgroup",
+                            "superOpt": "rw,seclabel,pids"
+                        },
+                        {
+                            "mountId": 42,
+                            "parentId": 30,
+                            "major": 0,
+                            "minor": 39,
+                            "root": "/",
+                            "mountPoint": "/sys/fs/cgroup/blkio",
+                            "options": "rw,nosuid,nodev,noexec,relatime",
+                            "fields": "shared:18",
+                            "type": "cgroup",
+                            "source": "cgroup",
+                            "superOpt": "rw,seclabel,blkio"
+                        },
+                        {
+                            "mountId": 43,
+                            "parentId": 30,
+                            "major": 0,
+                            "minor": 40,
+                            "root": "/",
+                            "mountPoint": "/sys/fs/cgroup/cpu,cpuacct",
+                            "options": "rw,nosuid,nodev,noexec,relatime",
+                            "fields": "shared:19",
+                            "type": "cgroup",
+                            "source": "cgroup",
+                            "superOpt": "rw,seclabel,cpu,cpuacct"
+                        },
+                        {
+                            "mountId": 44,
+                            "parentId": 23,
+                            "major": 0,
+                            "minor": 41,
+                            "root": "/",
+                            "mountPoint": "/sys/kernel/config",
+                            "options": "rw,relatime",
+                            "fields": "shared:22",
+                            "type": "configfs",
+                            "source": "configfs",
+                            "superOpt": "rw"
+                        },
+                        {
+                            "mountId": 45,
+                            "parentId": 1,
+                            "major": 259,
+                            "minor": 2,
+                            "root": "/",
+                            "mountPoint": "/",
+                            "options": "rw,noatime",
+                            "fields": "shared:1",
+                            "type": "xfs",
+                            "source": "/dev/nvme0n1p1",
+                            "superOpt": "rw,seclabel,attr2,inode64,logbufs=8,logbsize=32k,noquota"
+                        },
+                        {
+                            "mountId": 47,
+                            "parentId": 23,
+                            "major": 0,
+                            "minor": 21,
+                            "root": "/",
+                            "mountPoint": "/sys/fs/selinux",
+                            "options": "rw,relatime",
+                            "fields": "shared:23",
+                            "type": "selinuxfs",
+                            "source": "selinuxfs",
+                            "superOpt": "rw"
+                        },
+                        {
+                            "mountId": 46,
+                            "parentId": 24,
+                            "major": 0,
+                            "minor": 42,
+                            "root": "/",
+                            "mountPoint": "/proc/sys/fs/binfmt_misc",
+                            "options": "rw,relatime",
+                            "fields": "shared:25",
+                            "type": "autofs",
+                            "source": "systemd-1",
+                            "superOpt": "rw,fd=27,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=1793"
+                        },
+                        {
+                            "mountId": 48,
+                            "parentId": 25,
+                            "major": 0,
+                            "minor": 20,
+                            "root": "/",
+                            "mountPoint": "/dev/mqueue",
+                            "options": "rw,relatime",
+                            "fields": "shared:26",
+                            "type": "mqueue",
+                            "source": "mqueue",
+                            "superOpt": "rw,seclabel"
+                        },
+                        {
+                            "mountId": 49,
+                            "parentId": 23,
+                            "major": 0,
+                            "minor": 7,
+                            "root": "/",
+                            "mountPoint": "/sys/kernel/debug",
+                            "options": "rw,relatime",
+                            "fields": "shared:27",
+                            "type": "debugfs",
+                            "source": "debugfs",
+                            "superOpt": "rw,seclabel"
+                        },
+                        {
+                            "mountId": 50,
+                            "parentId": 25,
+                            "major": 0,
+                            "minor": 43,
+                            "root": "/",
+                            "mountPoint": "/dev/hugepages",
+                            "options": "rw,relatime",
+                            "fields": "shared:28",
+                            "type": "hugetlbfs",
+                            "source": "hugetlbfs",
+                            "superOpt": "rw,seclabel,pagesize=2M"
+                        },
+                        {
+                            "mountId": 51,
+                            "parentId": 45,
+                            "major": 259,
+                            "minor": 3,
+                            "root": "/",
+                            "mountPoint": "/boot/efi",
+                            "options": "rw,noatime",
+                            "fields": "shared:29",
+                            "type": "vfat",
+                            "source": "/dev/nvme0n1p128",
+                            "superOpt": "rw,fmask=0077,dmask=0077,codepage=437,iocharset=ascii,shortname=winnt,errors=remount-ro"
+                        },
+                        {
+                            "mountId": 52,
+                            "parentId": 45,
+                            "major": 0,
+                            "minor": 44,
+                            "root": "/",
+                            "mountPoint": "/var/lib/nfs/rpc_pipefs",
+                            "options": "rw,relatime",
+                            "fields": "shared:30",
+                            "type": "rpc_pipefs",
+                            "source": "sunrpc",
+                            "superOpt": "rw"
+                        },
+                        {
+                            "mountId": 93,
+                            "parentId": 45,
+                            "major": 259,
+                            "minor": 0,
+                            "root": "/",
+                            "mountPoint": "/srv/mongodb",
+                            "options": "rw,noatime",
+                            "fields": "shared:70",
+                            "type": "xfs",
+                            "source": "/dev/nvme1n1",
+                            "superOpt": "rw,seclabel,attr2,inode64,logbufs=8,logbsize=32k,sunit=8,swidth=8,noquota"
+                        }
+                    ]
+                }
+            },
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            }
+        },
+        "section": "server_info",
+        "subsection": "host_info",
+        "ts": {
+            "start": {
+                "$date": 1692958188337
+            },
+            "end": {
+                "$date": 1692958188448
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.serverCmdLineOpts();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "argv": [
+                "/var/lib/mongodb-mms-automation/mongodb-linux-aarch64-6.0.9-ent/bin/mongod",
+                "-f",
+                "/srv/mongodb/atlas-b5vr7t-shard-0-node-1/automation-mongod.conf"
+            ],
+            "parsed": {
+                "config": "/srv/mongodb/atlas-b5vr7t-shard-0-node-1/automation-mongod.conf",
+                "net": {
+                    "bindIp": "0.0.0.0",
+                    "compression": {
+                        "compressors": "snappy,zstd,zlib"
+                    },
+                    "maxIncomingConnections": 1500,
+                    "maxIncomingConnectionsOverride": [
+                        "127.0.0.1/32",
+                        "192.168.248.0/21"
+                    ],
+                    "port": 27017,
+                    "tls": {
+                        "CAFile": "/etc/pki/tls/certs/atlas-bundle.crt",
+                        "allowConnectionsWithoutCertificates": true,
+                        "certificateKeyFile": "/etc/pki/tls/private/mongod.pem",
+                        "clusterCAFile": "/var/lib/mongodb-mms-automation/atlas-cluster-managed.crt",
+                        "disabledProtocols": "TLS1_0,TLS1_1",
+                        "mode": "requireTLS"
+                    }
+                },
+                "processManagement": {
+                    "fork": true
+                },
+                "replication": {
+                    "replSetName": "atlas-b5vr7t-shard-0"
+                },
+                "security": {
+                    "authorization": "enabled",
+                    "javascriptEnabled": true,
+                    "keyFile": "/var/lib/mongodb-mms-automation/keyfile"
+                },
+                "setParameter": {
+                    "allowRolesFromX509Certificates": "true",
+                    "authenticationMechanisms": "SCRAM-SHA-1,SCRAM-SHA-256,MONGODB-AWS,MONGODB-X509",
+                    "awsSTSUrl": "https://sts.ap-south-1.amazonaws.com",
+                    "honorSystemUmask": "false",
+                    "internalQueryGlobalProfilingFilter": "true",
+                    "ldapForceMultiThreadMode": "true",
+                    "lockCodeSegmentsInMemory": "true",
+                    "maxIndexBuildMemoryUsageMegabytes": "100",
+                    "minSnapshotHistoryWindowInSeconds": "300",
+                    "mongotHost": "localhost:28000",
+                    "notablescan": "false",
+                    "reportOpWriteConcernCountersInServerStatus": "true",
+                    "searchIndexManagementHostAndPort": "/etc/mongodb-mms-automation/envoy/sockets/search-mms.sock",
+                    "suppressNoTLSPeerCertificateWarning": "true",
+                    "tlsCATrusts": "[{sha256: \"5C375E3D08DABDA4BA5809343F5489939C59A6B5299EBE5BE87B40A0F38B9E25\", roles: [{ role: \"\", db: \"\"}]}]",
+                    "tlsWithholdClientCertificate": "true",
+                    "ttlMonitorEnabled": "true",
+                    "watchdogPeriodSeconds": "60"
+                },
+                "storage": {
+                    "dbPath": "/srv/mongodb/atlas-b5vr7t-shard-0-node-1",
+                    "oplogMinRetentionHours": 24,
+                    "wiredTiger": {
+                        "engineConfig": {
+                            "configString": "cache_size=512MB"
+                        }
+                    }
+                },
+                "systemLog": {
+                    "destination": "file",
+                    "logAppend": true,
+                    "path": "/srv/mongodb/atlas-b5vr7t-shard-0-node-1/mongodb.log"
+                }
+            },
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            }
+        },
+        "section": "server_info",
+        "subsection": "command_line_info",
+        "ts": {
+            "start": {
+                "$date": 1692958188448
+            },
+            "end": {
+                "$date": 1692958188544
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.serverBuildInfo();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "version": "6.0.9",
+            "gitVersion": "90c65f9cc8fc4e6664a5848230abaa9b3f3b02f7",
+            "modules": [
+                "enterprise"
+            ],
+            "allocator": "tcmalloc",
+            "javascriptEngine": "mozjs",
+            "sysInfo": "deprecated",
+            "versionArray": [
+                6,
+                0,
+                9,
+                0
+            ],
+            "openssl": {
+                "running": "OpenSSL 1.0.2k-fips  26 Jan 2017",
+                "compiled": "OpenSSL 1.0.2k-fips  26 Jan 2017"
+            },
+            "buildEnvironment": {
+                "distmod": "amazon2",
+                "distarch": "aarch64",
+                "cc": "/opt/mongodbtoolchain/v3/bin/gcc: gcc (GCC) 8.5.0",
+                "ccflags": "-Werror -include mongo/platform/basic.h -ffp-contract=off -fasynchronous-unwind-tables -ggdb -Wall -Wsign-compare -Wno-unknown-pragmas -Winvalid-pch -fno-omit-frame-pointer -fno-strict-aliasing -O2 -march=armv8.2-a -mtune=generic -Wno-unused-local-typedefs -Wno-unused-function -Wno-deprecated-declarations -Wno-unused-const-variable -Wno-unused-but-set-variable -Wno-missing-braces -fstack-protector-strong -fdebug-types-section -Wa,--nocompress-debug-sections -moutline-atomics",
+                "cxx": "/opt/mongodbtoolchain/v3/bin/g++: g++ (GCC) 8.5.0",
+                "cxxflags": "-Woverloaded-virtual -Wno-maybe-uninitialized -fsized-deallocation -std=c++17",
+                "linkflags": "-Wl,--fatal-warnings -pthread -Wl,-z,now -fuse-ld=gold -fstack-protector-strong -fdebug-types-section -Wl,--no-threads -Wl,--build-id -Wl,--hash-style=gnu -Wl,-z,noexecstack -Wl,--warn-execstack -Wl,-z,relro -Wl,--compress-debug-sections=none -Wl,-rpath,/usr/lib64/perl5/CORE -Wl,-z,origin -Wl,--enable-new-dtags",
+                "target_arch": "aarch64",
+                "target_os": "linux",
+                "cppdefines": "SAFEINT_USE_INTRINSICS 0 PCRE_STATIC NDEBUG _XOPEN_SOURCE 700 _GNU_SOURCE _FORTIFY_SOURCE 2 BOOST_THREAD_VERSION 5 BOOST_THREAD_USES_DATETIME BOOST_SYSTEM_NO_DEPRECATED BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS BOOST_ENABLE_ASSERT_DEBUG_HANDLER BOOST_LOG_NO_SHORTHAND_NAMES BOOST_LOG_USE_NATIVE_SYSLOG BOOST_LOG_WITHOUT_THREAD_ATTR ABSL_FORCE_ALIGNED_ACCESS"
+            },
+            "bits": 64,
+            "debug": false,
+            "maxBsonObjectSize": 16777216,
+            "storageEngines": [
+                "devnull",
+                "ephemeralForTest",
+                "inMemory",
+                "queryable_wt",
+                "wiredTiger"
+            ],
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            }
+        },
+        "section": "server_info",
+        "subsection": "server_build_info",
+        "ts": {
+            "start": {
+                "$date": 1692958188544
+            },
+            "end": {
+                "$date": 1692958188635
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.adminCommand({getParameter: '*'});}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "KeysRotationIntervalSec": 7776000,
+            "ShardingTaskExecutorPoolHostTimeoutMS": 300000,
+            "ShardingTaskExecutorPoolMaxConnecting": 2,
+            "ShardingTaskExecutorPoolMaxSize": 32767,
+            "ShardingTaskExecutorPoolMaxSizeForConfigServers": -1,
+            "ShardingTaskExecutorPoolMinSize": 1,
+            "ShardingTaskExecutorPoolMinSizeForConfigServers": -1,
+            "ShardingTaskExecutorPoolRefreshRequirementMS": 60000,
+            "ShardingTaskExecutorPoolRefreshTimeoutMS": 20000,
+            "ShardingTaskExecutorPoolReplicaSetMatching": "automatic",
+            "TransactionRecordMinimumLifetimeMinutes": 30,
+            "aggregateOperationResourceConsumptionMetrics": false,
+            "allowDiskUseByDefault": true,
+            "allowMultipleArbiters": false,
+            "allowRolesFromX509Certificates": true,
+            "auditAuthorizationSuccess": false,
+            "auditConfigPollingFrequencySecs": 300,
+            "auditEncryptKeyWithKMIPGet": false,
+            "auditEncryptionHeaderMetadataFile": {
+                "$date": 1692958193923
+            },
+            "auditEncryptionWithKMS": false,
+            "authFailedDelayMs": 0,
+            "authSchemaVersion": 5,
+            "authenticationMechanisms": [
+                "SCRAM-SHA-1",
+                "SCRAM-SHA-256",
+                "MONGODB-AWS",
+                "MONGODB-X509"
+            ],
+            "authorizationManagerCacheSize": 100,
+            "authorizationManagerPinnedUsers": [],
+            "authorizationManagerPinnedUsersRefreshIntervalMillis": {
+                "$numberLong": "1000"
+            },
+            "awsEC2InstanceMetadataUrl": "http://169.254.169.254",
+            "awsECSInstanceMetadataUrl": "http://169.254.170.2",
+            "awsSTSRetryCount": 2,
+            "awsSTSUrl": "https://sts.ap-south-1.amazonaws.com",
+            "awsSTSUseConnectionPool": false,
+            "backtraceLogFile": {
+                "$date": 1692958193923
+            },
+            "balancerChunksSelectionTimeoutMs": 5000,
+            "balancerMigrationsThrottlingMs": 1000,
+            "batchedDeletesTargetBatchDocs": {
+                "$numberLong": "10"
+            },
+            "batchedDeletesTargetBatchTimeMS": {
+                "$numberLong": "5"
+            },
+            "batchedDeletesTargetStagedDocBytes": {
+                "$numberLong": "31457280"
+            },
+            "batchedExpiredChangeStreamPreImageRemoval": true,
+            "bgSyncOplogFetcherBatchSize": 13981010,
+            "changeSyncSourceThresholdMillis": {
+                "$numberLong": "5"
+            },
+            "chunkDefragmentationThrottlingMS": 1000,
+            "chunkMigrationConcurrency": 1,
+            "clientCursorMonitorFrequencySecs": 4,
+            "clusterAuthMode": "keyFile",
+            "clusterIpSourceAllowlist": null,
+            "collectionBulkLoaderBatchSizeInBytes": 262144,
+            "collectionClonerBatchSize": 0,
+            "collectionClonerUsesExhaust": true,
+            "connPoolMaxConnsPerHost": 200,
+            "connPoolMaxInUseConnsPerHost": 2147483647,
+            "connectTimeoutMs": 10000,
+            "coordinateCommitReturnImmediatelyAfterPersistingDecision": false,
+            "createRollbackDataFiles": true,
+            "cursorTimeoutMillis": {
+                "$numberLong": "600000"
+            },
+            "dbCheckCollectionTryLockMaxAttempts": 5,
+            "dbCheckCollectionTryLockMaxBackoffMillis": 60000,
+            "dbCheckCollectionTryLockMinBackoffMillis": 10,
+            "dbCheckCollectionTryLockTimeoutMillis": 10,
+            "dbCheckHealthLogEveryNBatches": 25,
+            "deprecatedWireOpsWarningPeriodInSeconds": 3600,
+            "diagnosticDataCollectionDirectoryPath": "/srv/mongodb/atlas-b5vr7t-shard-0-node-1/diagnostic.data",
+            "diagnosticDataCollectionDirectorySizeMB": 200,
+            "diagnosticDataCollectionEnableLatencyHistograms": false,
+            "diagnosticDataCollectionEnabled": true,
+            "diagnosticDataCollectionFileSizeMB": 10,
+            "diagnosticDataCollectionPeriodMillis": 1000,
+            "diagnosticDataCollectionSamplesPerChunk": 300,
+            "diagnosticDataCollectionSamplesPerInterimUpdate": 10,
+            "diagnosticDataCollectionStatsNamespaces": [],
+            "diagnosticDataCollectionVerboseTCMalloc": false,
+            "disableJavaScriptJIT": true,
+            "disableLogicalSessionCacheRefresh": false,
+            "disableNonSSLConnectionLogging": false,
+            "disableNonTLSConnectionLogging": false,
+            "disableResumableRangeDeleter": false,
+            "disableSplitHorizonIPCheck": false,
+            "disabledSecureAllocatorDomains": [],
+            "documentUnitSizeBytes": 128,
+            "enableDefaultWriteConcernUpdatesForInitiate": false,
+            "enableElectionHandoff": true,
+            "enableFinerGrainedCatalogCacheRefresh": false,
+            "enableFlowControl": true,
+            "enableLocalhostAuthBypass": true,
+            "enableOverrideClusterChainingSetting": false,
+            "enableSearchMeta": true,
+            "enableShardedIndexConsistencyCheck": true,
+            "enableTemporarilyUnavailableExceptions": false,
+            "enableTestCommands": false,
+            "enableTimeoutOfInactiveSessionCursors": false,
+            "enforceUserClusterSeparation": true,
+            "expiredChangeStreamPreImageRemovalJobSleepSecs": 10,
+            "fassertOnLockTimeoutForStepUpDown": 30,
+            "featureCompatibilityVersion": {
+                "version": "6.0"
+            },
+            "featureFlagAlwaysCreateConfigTransactionsPartialIndexOnStepUp": {
+                "value": false
+            },
+            "featureFlagBalanceAccordingToDataSize": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagBatchMultiDeletes": {
+                "value": false
+            },
+            "featureFlagBlender": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagBucketUnpackWithSort": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagChangeStreamPreAndPostImages": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagChangeStreamsRewrite": {
+                "value": true,
+                "version": "5.1"
+            },
+            "featureFlagChangeStreamsVisibility": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagClusterWideConfig": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagClusterWideConfigM2": {
+                "value": false
+            },
+            "featureFlagClusteredIndexes": {
+                "value": true,
+                "version": "5.3"
+            },
+            "featureFlagCollModIndexUnique": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagColumnstoreIndexes": {
+                "value": false
+            },
+            "featureFlagCommandsAcceptCollectionUUID": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagCommonQueryFramework": {
+                "value": false
+            },
+            "featureFlagConcurrencyInChunkMigration": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagConnHealthMetrics": {
+                "value": false
+            },
+            "featureFlagDerivedMetadata": {
+                "value": false
+            },
+            "featureFlagDocumentSourceListCatalog": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagEnableExecutionControl": {
+                "value": false
+            },
+            "featureFlagEnableShardingOptional": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagExactTopNAccumulator": {
+                "value": true,
+                "version": "5.2"
+            },
+            "featureFlagFLE2": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagFileCopyBasedInitialSync": {
+                "value": true,
+                "version": "5.2"
+            },
+            "featureFlagFill": {
+                "value": true,
+                "version": "5.3"
+            },
+            "featureFlagFryer": {
+                "value": false
+            },
+            "featureFlagHealthMonitoring": {
+                "value": true,
+                "version": "5.3"
+            },
+            "featureFlagInternalTransactions": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagLastPointQuery": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagLoadBalancer": {
+                "value": true,
+                "version": "5.3"
+            },
+            "featureFlagLocf": {
+                "value": true,
+                "version": "5.2"
+            },
+            "featureFlagMigrationRecipientCriticalSection": {
+                "value": true,
+                "version": "5.3"
+            },
+            "featureFlagMongoStore": {
+                "value": false
+            },
+            "featureFlagNewPersistedChunkVersionFormat": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagNewWriteErrorExceptionFormat": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagNoChangeStreamEventsDueToOrphans": {
+                "value": true,
+                "version": "5.3"
+            },
+            "featureFlagNoMoreAutoSplitter": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagOptionalCfgSvr": {
+                "value": false
+            },
+            "featureFlagOrphanTracking": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagPerCollBalancingSettings": {
+                "value": true,
+                "version": "5.3"
+            },
+            "featureFlagRecoverableRefineCollectionShardKeyCoordinator": {
+                "value": true,
+                "version": "5.3"
+            },
+            "featureFlagRecoverableShardsvrReshardCollectionCoordinator": {
+                "value": true,
+                "version": "5.3"
+            },
+            "featureFlagRequireTenantID": {
+                "value": false
+            },
+            "featureFlagResharding": {
+                "value": true,
+                "version": "5.0"
+            },
+            "featureFlagRetryableFindAndModify": {
+                "value": true,
+                "version": "5.1"
+            },
+            "featureFlagSBEGroupPushdown": {
+                "value": true,
+                "version": "5.2"
+            },
+            "featureFlagSBELookupPushdown": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagSbeFull": {
+                "value": false
+            },
+            "featureFlagSbePlanCache": {
+                "value": false
+            },
+            "featureFlagSearchBatchSizeLimit": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagSearchMeta": {
+                "value": true,
+                "version": "5.1"
+            },
+            "featureFlagSearchShardedFacets": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagSelectiveBackup": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagShardMerge": {
+                "value": false
+            },
+            "featureFlagShardSplit": {
+                "value": false
+            },
+            "featureFlagShardedLookup": {
+                "value": true,
+                "version": "5.1"
+            },
+            "featureFlagShardedSearchCustomSort": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagShardedTimeSeries": {
+                "value": true,
+                "version": "5.1"
+            },
+            "featureFlagShardedTimeSeriesUpdateDelete": {
+                "value": true,
+                "version": "5.1"
+            },
+            "featureFlagShardingDataTransformMetrics": {
+                "value": false
+            },
+            "featureFlagSortArray": {
+                "value": true,
+                "version": "5.2"
+            },
+            "featureFlagSpoon": {
+                "value": true,
+                "version": "5.0"
+            },
+            "featureFlagTimeseriesBucketCompression": {
+                "value": true,
+                "version": "5.2"
+            },
+            "featureFlagTimeseriesBucketCompressionWithArrays": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagTimeseriesMetricIndexes": {
+                "value": true,
+                "version": "6.0"
+            },
+            "featureFlagTimeseriesUpdatesAndDeletes": {
+                "value": true,
+                "version": "5.0"
+            },
+            "featureFlagToaster": {
+                "value": false
+            },
+            "featureFlagUpdateDocumentShardKeyUsingTransactionApi": {
+                "value": false
+            },
+            "featureFlagUserWriteBlocking": {
+                "value": true,
+                "version": "6.0"
+            },
+            "fileBasedInitialSyncExtendCursorTimeoutMS": 180000,
+            "fileBasedInitialSyncMaxCyclesWithoutProgress": 3,
+            "fileBasedInitialSyncMaxLagSec": 300,
+            "findChunksOnConfigTimeoutMS": 900000,
+            "fixedServiceExecutorRecursionLimit": 8,
+            "fixedServiceExecutorThreadLimit": 1000,
+            "flowControlDecayConstant": 0.5,
+            "flowControlFudgeFactor": 0.95,
+            "flowControlMaxSamples": 1000000,
+            "flowControlMinTicketsPerSecond": 100,
+            "flowControlSamplePeriod": 1000,
+            "flowControlTargetLagSeconds": 10,
+            "flowControlThresholdLagPercentage": 0.5,
+            "flowControlTicketAdderConstant": 1000,
+            "flowControlTicketMultiplierConstant": 1.05,
+            "flowControlWarnThresholdSeconds": 10,
+            "forceRollbackViaRefetch": false,
+            "globalConnPoolIdleTimeoutMinutes": 2147483647,
+            "heapProfilingEnabled": false,
+            "heapProfilingSampleIntervalBytes": {
+                "$numberLong": "262144"
+            },
+            "heartBeatFrequencyMs": 10000,
+            "honorSystemUmask": false,
+            "httpVerboseLogging": false,
+            "indexEntryUnitSizeBytes": 16,
+            "indexMaxNumGeneratedKeysPerDocument": 100000,
+            "initialServiceExecutorThreadingModel": "dedicated",
+            "initialSyncMethod": "logical",
+            "initialSyncOplogBuffer": "collection",
+            "initialSyncOplogBufferPeekCacheSize": 10000,
+            "initialSyncOplogFetcherBatchSize": 13981010,
+            "initialSyncSourceReadPreference": {
+                "$date": 1692958193925
+            },
+            "initialSyncTransientErrorRetryPeriodSeconds": 86400,
+            "internalBatchUserMultiDeletesForTest": false,
+            "internalCascadesOptimizerDisableBranchAndBound": false,
+            "internalCascadesOptimizerDisableGroupByAndUnionRIDIntersect": false,
+            "internalCascadesOptimizerDisableHashJoinRIDIntersect": false,
+            "internalCascadesOptimizerDisableIndexes": false,
+            "internalCascadesOptimizerDisableMergeJoinRIDIntersect": false,
+            "internalCascadesOptimizerDisableScan": false,
+            "internalCascadesOptimizerKeepRejectedPlans": false,
+            "internalDocumentSourceCursorBatchSizeBytes": 4194304,
+            "internalDocumentSourceDensifyMaxMemoryBytes": 104857600,
+            "internalDocumentSourceGroupMaxMemoryBytes": {
+                "$numberLong": "104857600"
+            },
+            "internalDocumentSourceLookupCacheSizeBytes": 104857600,
+            "internalDocumentSourceSetWindowFieldsMaxMemoryBytes": {
+                "$numberLong": "104857600"
+            },
+            "internalGeoNearQuery2DMaxCoveringCells": 16,
+            "internalGeoPredicateQuery2DMaxCoveringCells": 16,
+            "internalIndexBuildBulkLoadYieldIterations": 1000,
+            "internalInsertMaxBatchSize": 500,
+            "internalLookupStageIntermediateDocumentMaxSizeBytes": {
+                "$numberLong": "104857600"
+            },
+            "internalPartialFilterExpressionMaxDepth": {
+                "$numberLong": "4"
+            },
+            "internalPipelineLengthLimit": 1000,
+            "internalProhibitShardOperationRetry": false,
+            "internalQueryAlwaysMergeOnPrimaryShard": false,
+            "internalQueryAppendIdToSetWindowFieldsSort": false,
+            "internalQueryCacheDisableInactiveEntries": false,
+            "internalQueryCacheEvictionRatio": 10,
+            "internalQueryCacheMaxEntriesPerCollection": 5000,
+            "internalQueryCacheMaxSizeBytesBeforeStripDebugInfo": {
+                "$numberLong": "536870912"
+            },
+            "internalQueryCacheSize": 5000,
+            "internalQueryCacheWorksGrowthCoefficient": 2,
+            "internalQueryCollectionMaxDataSizeBytesToChooseHashJoin": {
+                "$numberLong": "104857600"
+            },
+            "internalQueryCollectionMaxNoOfDocumentsToChooseHashJoin": {
+                "$numberLong": "10000"
+            },
+            "internalQueryCollectionMaxStorageSizeBytesToChooseHashJoin": {
+                "$numberLong": "104857600"
+            },
+            "internalQueryDesugarWhereToFunction": false,
+            "internalQueryDisableExchange": false,
+            "internalQueryDisableLookupExecutionUsingHashJoin": false,
+            "internalQueryDocumentSourceWriterBatchExtraReservedBytes": 0,
+            "internalQueryEnableCSTParser": false,
+            "internalQueryEnableCascadesOptimizer": false,
+            "internalQueryEnableLoggingV2OplogEntries": true,
+            "internalQueryEnableSamplingCardinalityEstimator": true,
+            "internalQueryEnumerationMaxIntersectPerAnd": 3,
+            "internalQueryEnumerationMaxOrSolutions": 10,
+            "internalQueryEnumerationPreferLockstepOrEnumeration": false,
+            "internalQueryExecYieldIterations": 1000,
+            "internalQueryExecYieldPeriodMS": 10,
+            "internalQueryExplainSizeThresholdBytes": 10485760,
+            "internalQueryFLEAlwaysUseHighCardinalityMode": false,
+            "internalQueryFLERewriteMemoryLimit": 14680064,
+            "internalQueryFacetBufferSizeBytes": 104857600,
+            "internalQueryFacetMaxOutputDocSizeBytes": {
+                "$numberLong": "104857600"
+            },
+            "internalQueryForceClassicEngine": false,
+            "internalQueryForceIntersectionPlans": false,
+            "internalQueryGlobalProfilingFilter": true,
+            "internalQueryIgnoreUnknownJSONSchemaKeywords": false,
+            "internalQueryJavaScriptFnTimeoutMillis": 60000,
+            "internalQueryJavaScriptHeapSizeLimitMB": 100,
+            "internalQueryMaxAddToSetBytes": {
+                "$numberLong": "104857600"
+            },
+            "internalQueryMaxAllowedDensifyDocs": 500000,
+            "internalQueryMaxBlockingSortMemoryUsageBytes": 104857600,
+            "internalQueryMaxDocValidationErrorConsideredValues": 10,
+            "internalQueryMaxJsEmitBytes": 104857600,
+            "internalQueryMaxNumberOfFieldsToChooseFilteredColumnScan": 12,
+            "internalQueryMaxNumberOfFieldsToChooseUnfilteredColumnScan": 5,
+            "internalQueryMaxPushBytes": 104857600,
+            "internalQueryMaxRangeBytes": 104857600,
+            "internalQueryMaxScansToExplode": 200,
+            "internalQueryPlanEvaluationCollFraction": 0.3,
+            "internalQueryPlanEvaluationCollFractionSbe": 0,
+            "internalQueryPlanEvaluationMaxResults": 101,
+            "internalQueryPlanEvaluationWorks": 10000,
+            "internalQueryPlanEvaluationWorksSbe": 10000,
+            "internalQueryPlanOrChildrenIndependently": true,
+            "internalQueryPlannerEnableHashIntersection": false,
+            "internalQueryPlannerEnableIndexIntersection": true,
+            "internalQueryPlannerGenerateCoveredWholeIndexScans": false,
+            "internalQueryPlannerMaxIndexedSolutions": 64,
+            "internalQueryProhibitBlockingMergeOnMongoS": false,
+            "internalQueryProhibitMergingOnMongoS": false,
+            "internalQueryS2GeoCoarsestLevel": 0,
+            "internalQueryS2GeoFinestLevel": 23,
+            "internalQueryS2GeoMaxCells": 20,
+            "internalQuerySlotBasedExecutionDisableGroupPushdown": false,
+            "internalQuerySlotBasedExecutionDisableLookupPushdown": false,
+            "internalQuerySlotBasedExecutionHashAggApproxMemoryUseInBytesBeforeSpill": {
+                "$numberLong": "104857600"
+            },
+            "internalQuerySlotBasedExecutionHashAggMemoryCheckPerAdvanceAtLeast": {
+                "$numberLong": "1024"
+            },
+            "internalQuerySlotBasedExecutionHashAggMemoryCheckPerAdvanceAtMost": {
+                "$numberLong": "2"
+            },
+            "internalQuerySlotBasedExecutionHashAggMemoryUseCheckMargin": 0.7,
+            "internalQuerySlotBasedExecutionHashLookupApproxMemoryUseInBytesBeforeSpill": {
+                "$numberLong": "104857600"
+            },
+            "internalQuerySlotBasedExecutionMaxStaticIndexScanIntervals": 1000,
+            "internalQueryTopNAccumulatorBytes": 104857600,
+            "internalSessionsReapThreshold": 1000,
+            "internalValidateFeaturesAsMaster": true,
+            "internalValidateFeaturesAsPrimary": true,
+            "javascriptProtection": false,
+            "joinIngressSessionsOnShutdown": false,
+            "journalCommitInterval": 100,
+            "jsHeapLimitMB": 1100,
+            "ldapAbortOnNameMappingFailure": true,
+            "ldapAuthzQueryTemplate": {
+                "$date": 1692958193925
+            },
+            "ldapConnectionPoolHostRefreshIntervalMillis": 60000,
+            "ldapConnectionPoolIdleHostTimeoutSecs": 300,
+            "ldapConnectionPoolMaximumConnectionsInProgressPerHost": 2,
+            "ldapConnectionPoolMaximumConnectionsPerHost": 2147483647,
+            "ldapConnectionPoolMinimumConnectionsPerHost": 1,
+            "ldapConnectionPoolUseLatencyForHostPriority": true,
+            "ldapForceMultiThreadMode": true,
+            "ldapQueryPassword": "###",
+            "ldapQueryUser": {
+                "$date": 1692958193925
+            },
+            "ldapServers": {
+                "$date": 1692958193925
+            },
+            "ldapShouldRefreshUserCacheEntries": true,
+            "ldapTimeoutMS": {
+                "$numberLong": "10000"
+            },
+            "ldapUseConnectionPool": true,
+            "ldapUserCacheInvalidationInterval": 30,
+            "ldapUserCacheRefreshInterval": 30,
+            "ldapUserCacheStalenessInterval": 90,
+            "ldapUserToDNMapping": "[]",
+            "loadBalancerPort": 0,
+            "loadRoutingTableOnStartup": true,
+            "localLogicalSessionTimeoutMinutes": 30,
+            "localThresholdMs": 15,
+            "lockCodeSegmentsInMemory": true,
+            "logComponentVerbosity": {
+                "verbosity": 0,
+                "accessControl": {
+                    "verbosity": -1
+                },
+                "assert": {
+                    "verbosity": -1
+                },
+                "command": {
+                    "verbosity": -1
+                },
+                "control": {
+                    "verbosity": -1
+                },
+                "executor": {
+                    "verbosity": -1
+                },
+                "geo": {
+                    "verbosity": -1
+                },
+                "index": {
+                    "verbosity": -1
+                },
+                "network": {
+                    "verbosity": -1,
+                    "asio": {
+                        "verbosity": -1
+                    },
+                    "bridge": {
+                        "verbosity": -1
+                    },
+                    "connectionPool": {
+                        "verbosity": -1
+                    }
+                },
+                "processHealth": {
+                    "verbosity": -1
+                },
+                "query": {
+                    "verbosity": -1
+                },
+                "replication": {
+                    "verbosity": -1,
+                    "election": {
+                        "verbosity": -1
+                    },
+                    "heartbeats": {
+                        "verbosity": -1
+                    },
+                    "initialSync": {
+                        "verbosity": -1
+                    },
+                    "rollback": {
+                        "verbosity": -1
+                    }
+                },
+                "sharding": {
+                    "verbosity": -1,
+                    "rangeDeleter": {
+                        "verbosity": -1
+                    },
+                    "shardingCatalogRefresh": {
+                        "verbosity": -1
+                    },
+                    "migration": {
+                        "verbosity": -1
+                    },
+                    "reshard": {
+                        "verbosity": -1
+                    },
+                    "migrationPerf": {
+                        "verbosity": -1
+                    }
+                },
+                "storage": {
+                    "verbosity": -1,
+                    "recovery": {
+                        "verbosity": -1
+                    },
+                    "journal": {
+                        "verbosity": -1
+                    },
+                    "wt": {
+                        "verbosity": -1,
+                        "wtBackup": {
+                            "verbosity": -1
+                        },
+                        "wtCheckpoint": {
+                            "verbosity": -1
+                        },
+                        "wtCompact": {
+                            "verbosity": -1
+                        },
+                        "wtEviction": {
+                            "verbosity": -1
+                        },
+                        "wtHS": {
+                            "verbosity": -1
+                        },
+                        "wtRecovery": {
+                            "verbosity": -1
+                        },
+                        "wtRTS": {
+                            "verbosity": -1
+                        },
+                        "wtSalvage": {
+                            "verbosity": -1
+                        },
+                        "wtTiered": {
+                            "verbosity": -1
+                        },
+                        "wtTimestamp": {
+                            "verbosity": -1
+                        },
+                        "wtTransaction": {
+                            "verbosity": -1
+                        },
+                        "wtVerify": {
+                            "verbosity": -1
+                        },
+                        "wtWriteLog": {
+                            "verbosity": -1
+                        }
+                    }
+                },
+                "write": {
+                    "verbosity": -1
+                },
+                "ftdc": {
+                    "verbosity": -1
+                },
+                "tracking": {
+                    "verbosity": -1
+                },
+                "transaction": {
+                    "verbosity": -1
+                },
+                "tenantMigration": {
+                    "verbosity": -1
+                },
+                "test": {
+                    "verbosity": -1
+                }
+            },
+            "logLevel": 0,
+            "logicalSessionRefreshMillis": 300000,
+            "maintainValidCursorsAcrossSBEYieldandReadCommands": false,
+            "maxAcceptableLogicalClockDriftSecs": {
+                "$numberLong": "31536000"
+            },
+            "maxBSONDepth": 200,
+            "maxCatchUpPercentageBeforeBlockingWrites": 10,
+            "maxIndexBuildDrainBatchSize": 1000,
+            "maxIndexBuildDrainMemoryUsageMegabytes": 16,
+            "maxIndexBuildMemoryUsageMegabytes": 100,
+            "maxLogSizeKB": 10,
+            "maxNumActiveUserIndexBuilds": 3,
+            "maxNumSyncSourceChangesPerHour": 3,
+            "maxNumberOfTransactionOperationsInSingleOplogEntry": 2147483647,
+            "maxOplogTruncationPointsAfterStartup": {
+                "$numberLong": "100"
+            },
+            "maxOplogTruncationPointsDuringStartup": {
+                "$numberLong": "100"
+            },
+            "maxSessions": 1000000,
+            "maxSyncSourceLagSecs": 30,
+            "maxTenantMigrationDonorServiceThreadPoolSize": 8,
+            "maxTenantMigrationRecipientThreadPoolSize": 128,
+            "maxTimeMSForHedgedReads": 150,
+            "maxTransactionLockRequestTimeoutMillis": 5,
+            "maxValidateMBperSec": 0,
+            "maxValidateMemoryUsageMB": 200,
+            "metadataRefreshInTransactionMaxWaitBehindCritSecMS": 500,
+            "migrateCloneInsertionBatchDelayMS": 0,
+            "migrateCloneInsertionBatchSize": 0,
+            "migrationLockAcquisitionMaxWaitMS": 500,
+            "minNumChunksForSessionsCollection": 1024,
+            "minOplogEntriesPerThread": 16,
+            "minOplogTruncationPoints": {
+                "$numberLong": "10"
+            },
+            "minSnapshotHistoryWindowInSeconds": 300,
+            "mirrorReads": {
+                "samplingRate": 0.01,
+                "maxTimeMS": 1000
+            },
+            "mongosShutdownTimeoutMillisForSignaledShutdown": 15000,
+            "mongotConnectionPoolMaxSize": 32767,
+            "mongotConnectionPoolMinSize": 1,
+            "mongotHost": "localhost:28000",
+            "mrEnableSingleReduceOptimization": false,
+            "multitenancySupport": false,
+            "newShardExistingClusterTimeKeysExpirationSecs": 604800,
+            "notablescan": false,
+            "numInitialSyncAttempts": 10,
+            "numInitialSyncConnectAttempts": 10,
+            "numInitialSyncOplogFindAttempts": 3,
+            "ocspCacheSize": 300,
+            "ocspEnabled": true,
+            "ocspStaplingRefreshPeriodSecs": {
+                "$numberLong": "-1"
+            },
+            "ocspValidationRefreshPeriodSecs": {
+                "$numberLong": "-1"
+            },
+            "opensslCipherConfig": "HIGH:!EXPORT:!aNULL@STRENGTH",
+            "opensslCipherSuiteConfig": {
+                "$date": 1692958193926
+            },
+            "opensslDiffieHellmanParameters": {
+                "$date": 1692958193926
+            },
+            "operationMemoryPoolBlockInitialSizeKB": 1,
+            "operationMemoryPoolBlockMaxSizeKB": 2048,
+            "oplogApplicationEnforcesSteadyStateConstraints": false,
+            "oplogBatchDelayMillis": 0,
+            "oplogFetcherInitialSyncMaxFetcherRestarts": 10,
+            "oplogFetcherSteadyStateMaxFetcherRestarts": 1,
+            "oplogFetcherUsesExhaust": true,
+            "oplogInitialFindMaxSeconds": 60,
+            "oplogNetworkTimeoutBufferSeconds": 5,
+            "oplogRetriedFindMaxSeconds": 2,
+            "oplogSamplingLogIntervalSeconds": 10,
+            "oplogTruncationPointSizeMB": 0,
+            "opportunisticSecondaryTargeting": false,
+            "orphanCleanupDelaySecs": 900,
+            "periodicNoopIntervalSecs": 10,
+            "pinTaskExecCursorConns": false,
+            "planCacheSize": "5%",
+            "priorityTakeoverFreshnessWindowSeconds": 2,
+            "processUmask": 63,
+            "profileOperationResourceConsumptionMetrics": false,
+            "quiet": false,
+            "rangeDeleterBatchDelayMS": 20,
+            "rangeDeleterBatchSize": 2147483647,
+            "readHedgingMode": "on",
+            "receiveChunkWaitForRangeDeleterTimeoutMS": 10000,
+            "recoverFromOplogAsStandalone": false,
+            "recoverToOplogTimestamp": {
+                "$date": 1692958193926
+            },
+            "redactClientLogData": false,
+            "remainingReshardingOperationTimeThresholdMillis": 2000,
+            "replBatchLimitBytes": 104857600,
+            "replBatchLimitOperations": 5000,
+            "replElectionTimeoutOffsetLimitFraction": 0.15,
+            "replWriterMinThreadCount": 0,
+            "replWriterThreadCount": 16,
+            "replicaSetMonitorProtocol": "streamable",
+            "reportOpWriteConcernCountersInServerStatus": true,
+            "reservedServiceExecutorRecursionLimit": 8,
+            "reshardingCollectionClonerBatchSizeInBytes": 102400,
+            "reshardingCoordinatorServiceMaxThreadCount": 3,
+            "reshardingCriticalSectionTimeoutMillis": 5000,
+            "reshardingDonorServiceMaxThreadCount": 2,
+            "reshardingMinimumOperationDurationMillis": 300000,
+            "reshardingOplogApplierMaxLockRequestTimeoutMillis": 5,
+            "reshardingOplogBatchLimitBytes": 104857600,
+            "reshardingOplogBatchLimitOperations": 5000,
+            "reshardingOplogBatchTaskCount": 4,
+            "reshardingRecipientServiceMaxThreadCount": 8,
+            "reshardingTxnClonerProgressBatchSize": 1000,
+            "resumableIndexBuildMajorityOpTimeTimeoutMillis": {
+                "$numberLong": "10000"
+            },
+            "rewriteStateChangeErrors": true,
+            "rollbackRemoteOplogQueryBatchSize": 2000,
+            "rollbackTimeLimitSecs": 86400,
+            "roundtripBsonColumnOnValidate": false,
+            "saslHostName": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+            "saslServiceName": "mongodb",
+            "saslauthdPath": {
+                "$date": 1692958193926
+            },
+            "scramIterationCount": 10000,
+            "scramSHA256IterationCount": 15000,
+            "scriptingEngineInterruptIntervalMS": 1000,
+            "searchIndexManagementHostAndPort": "/etc/mongodb-mms-automation/envoy/sockets/search-mms.sock",
+            "shardSplitGarbageCollectionDelayMS": 900000,
+            "shardSplitTimeoutMS": 3600000,
+            "shardedIndexConsistencyCheckIntervalMS": 600000,
+            "shutdownTimeoutMillisForSignaledShutdown": 15000,
+            "skipAuthenticationToMongot": false,
+            "skipAuthenticationToSearchIndexManagementServer": true,
+            "skipCorruptDocumentsWhenCloning": false,
+            "skipShardingConfigurationChecks": false,
+            "skipShellCursorFinalize": false,
+            "sslMode": "requireSSL",
+            "sslWithholdClientCertificate": true,
+            "startupAuthSchemaValidation": true,
+            "startupRecoveryForRestore": false,
+            "storageEngineConcurrentReadTransactions": 0,
+            "storageEngineConcurrentWriteTransactions": 0,
+            "storageEngineQueueingPolicy": "fifoQueue",
+            "storageGlobalParams.directoryperdb": false,
+            "storeFindAndModifyImagesInSideCollection": true,
+            "suppressNetworkInterfaceTransportLayerExceptions": {
+                "value": false
+            },
+            "suppressNoTLSPeerCertificateWarning": true,
+            "syncdelay": 60,
+            "synchronousServiceExecutorRecursionLimit": 8,
+            "takeUnstableCheckpointOnShutdown": false,
+            "taskExecutorPoolSize": 1,
+            "tcmallocAggressiveMemoryDecommit": 0,
+            "tcmallocMaxTotalThreadCacheBytes": 242221056,
+            "tcmallocReleaseRate": 1,
+            "tcpFastOpenClient": true,
+            "tcpFastOpenQueueSize": 1024,
+            "tcpFastOpenServer": true,
+            "temporarilyUnavailableBackoffBaseMs": {
+                "$numberLong": "1000"
+            },
+            "temporarilyUnavailableMaxRetries": {
+                "$numberLong": "10"
+            },
+            "tenantApplierBatchSizeBytes": 16777216,
+            "tenantApplierBatchSizeOps": 500,
+            "tenantApplierThreadCount": 5,
+            "tenantMigrationBlockingStateTimeoutMS": 3600000,
+            "tenantMigrationDisableX509Auth": false,
+            "tenantMigrationExcludeDonorHostTimeoutMS": 60000,
+            "tenantMigrationExternalKeysRemovalBufferSecs": 86400,
+            "tenantMigrationGarbageCollectionDelayMS": 900000,
+            "tenantMigrationOplogBufferPeekCacheSize": 10000,
+            "tenantMigrationOplogFetcherBatchSize": 13981010,
+            "testingDiagnosticsEnabled": false,
+            "testingSnapshotBehaviorInIsolation": false,
+            "timeseriesBucketMaxCount": 1000,
+            "timeseriesBucketMaxSize": 128000,
+            "timeseriesIdleBucketExpiryMaxCountPerAttempt": 3,
+            "timeseriesIdleBucketExpiryMemoryUsageThreshold": {
+                "$numberLong": "0"
+            },
+            "timeseriesInsertMaxRetriesOnDuplicates": 32,
+            "timeseriesValidateCompressedBuckets": true,
+            "tlsCATrusts": [
+                {
+                    "sha256": "5C375E3D08DABDA4BA5809343F5489939C59A6B5299EBE5BE87B40A0F38B9E25",
+                    "roles": [
+                        {
+                            "role": {
+                                "$date": 1692958193926
+                            },
+                            "db": {
+                                "$date": 1692958193926
+                            }
+                        }
+                    ]
+                }
+            ],
+            "tlsMode": "requireTLS",
+            "tlsOCSPSlowResponderWarningSecs": 5,
+            "tlsOCSPStaplingTimeoutSecs": -1,
+            "tlsOCSPVerifyTimeoutSecs": 4,
+            "tlsWithholdClientCertificate": true,
+            "tlsX509ExpirationWarningThresholdDays": 30,
+            "totalUnitWriteSizeBytes": 128,
+            "traceExceptions": false,
+            "traceWriteConflictExceptions": false,
+            "trafficRecordingDirectory": {
+                "$date": 1692958193926
+            },
+            "transactionLifetimeLimitSeconds": 60,
+            "transactionSizeLimitBytes": {
+                "$numberLong": "9223372036854775807"
+            },
+            "transactionTooLargeForCacheThreshold": 0.75,
+            "ttlMonitorEnabled": true,
+            "ttlMonitorSleepSecs": 60,
+            "unsupportedSyncSource": {
+                "$date": 1692958193926
+            },
+            "useReadOnceCursorsForIndexBuilds": true,
+            "waitForSecondaryBeforeNoopWriteMS": 10,
+            "warmMinConnectionsInShardingTaskExecutorPoolOnStartup": true,
+            "warmMinConnectionsInShardingTaskExecutorPoolOnStartupWaitMS": 2000,
+            "watchdogPeriodSeconds": 60,
+            "wiredTigerConcurrentReadTransactions": 0,
+            "wiredTigerConcurrentWriteTransactions": 0,
+            "wiredTigerCursorCacheSize": -100,
+            "wiredTigerDirectoryForIndexes": false,
+            "wiredTigerEngineRuntimeConfig": {
+                "$date": 1692958193926
+            },
+            "wiredTigerEvictionDirtyMaxGB": 0,
+            "wiredTigerEvictionDirtyTargetGB": 0,
+            "wiredTigerFileHandleCloseIdleTime": 600,
+            "wiredTigerFileHandleCloseMinimum": 2000,
+            "wiredTigerFileHandleCloseScanInterval": 10,
+            "wiredTigerMaxCacheOverflowSizeGB": 0,
+            "wiredTigerSessionCloseIdleTimeSecs": 300,
+            "wiredTigerSkipTableLoggingChecksOnStartup": false,
+            "wiredTigerStressConfig": false,
+            "writePeriodicNoops": true,
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            }
+        },
+        "section": "server_info",
+        "subsection": "server_parameters",
+        "ts": {
+            "start": {
+                "$date": 1692958188635
+            },
+            "end": {
+                "$date": 1692958188753
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.isMaster();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "topologyVersion": {
+                "processId": {
+                    "$oid": "64e876a8d4b39ffc57f842a7"
+                },
+                "counter": {
+                    "$numberLong": "7"
+                }
+            },
+            "hosts": [
+                "ac-xqaamls-shard-00-00.mns8wfq.mongodb.net:27017",
+                "ac-xqaamls-shard-00-01.mns8wfq.mongodb.net:27017",
+                "ac-xqaamls-shard-00-02.mns8wfq.mongodb.net:27017"
+            ],
+            "setName": "atlas-b5vr7t-shard-0",
+            "setVersion": 1,
+            "ismaster": true,
+            "secondary": false,
+            "primary": "ac-xqaamls-shard-00-01.mns8wfq.mongodb.net:27017",
+            "tags": {
+                "provider": "AWS",
+                "workloadType": "OPERATIONAL",
+                "region": "AP_SOUTH_1",
+                "nodeType": "ELECTABLE"
+            },
+            "me": "ac-xqaamls-shard-00-01.mns8wfq.mongodb.net:27017",
+            "electionId": {
+                "$oid": "7fffffff0000000000000002"
+            },
+            "lastWrite": {
+                "opTime": {
+                    "ts": {
+                        "$timestamp": {
+                            "t": 1692958184,
+                            "i": 1
+                        }
+                    },
+                    "t": {
+                        "$numberLong": "2"
+                    }
+                },
+                "lastWriteDate": {
+                    "$date": 1692958184000
+                },
+                "majorityOpTime": {
+                    "ts": {
+                        "$timestamp": {
+                            "t": 1692958184,
+                            "i": 1
+                        }
+                    },
+                    "t": {
+                        "$numberLong": "2"
+                    }
+                },
+                "majorityWriteDate": {
+                    "$date": 1692958184000
+                }
+            },
+            "maxBsonObjectSize": 16777216,
+            "maxMessageSizeBytes": 48000000,
+            "maxWriteBatchSize": 100000,
+            "localTime": {
+                "$date": 1692958189113
+            },
+            "logicalSessionTimeoutMinutes": 30,
+            "connectionId": 646,
+            "minWireVersion": 0,
+            "maxWireVersion": 17,
+            "readOnly": false,
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            },
+            "isWritablePrimary": true
+        },
+        "section": "shard_or_replicaset_info",
+        "subsection": "ismaster",
+        "ts": {
+            "start": {
+                "$date": 1692958188754
+            },
+            "end": {
+                "$date": 1692958188833
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return rs.conf();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "_id": "atlas-b5vr7t-shard-0",
+            "version": 1,
+            "term": 2,
+            "members": [
+                {
+                    "_id": 0,
+                    "host": "atlas-b5vr7t-shard-00-00.mns8wfq.mongodb.net:27017",
+                    "arbiterOnly": false,
+                    "buildIndexes": true,
+                    "hidden": false,
+                    "priority": 6.5,
+                    "tags": {
+                        "nodeType": "ELECTABLE",
+                        "provider": "AWS",
+                        "region": "AP_SOUTH_1",
+                        "workloadType": "OPERATIONAL"
+                    },
+                    "horizons": {
+                        "MESH": "ac-xqaamls-shard-00-00.mns8wfq.mesh.mongodb.net:30432",
+                        "PRIVATE": "ac-xqaamls-shard-00-00-pri.mns8wfq.mongodb.net:27017",
+                        "PUBLIC": "ac-xqaamls-shard-00-00.mns8wfq.mongodb.net:27017"
+                    },
+                    "secondaryDelaySecs": {
+                        "$numberLong": "0"
+                    },
+                    "votes": 1
+                },
+                {
+                    "_id": 1,
+                    "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net:27017",
+                    "arbiterOnly": false,
+                    "buildIndexes": true,
+                    "hidden": false,
+                    "priority": 7,
+                    "tags": {
+                        "provider": "AWS",
+                        "region": "AP_SOUTH_1",
+                        "workloadType": "OPERATIONAL",
+                        "nodeType": "ELECTABLE"
+                    },
+                    "horizons": {
+                        "MESH": "ac-xqaamls-shard-00-01.mns8wfq.mesh.mongodb.net:30432",
+                        "PRIVATE": "ac-xqaamls-shard-00-01-pri.mns8wfq.mongodb.net:27017",
+                        "PUBLIC": "ac-xqaamls-shard-00-01.mns8wfq.mongodb.net:27017"
+                    },
+                    "secondaryDelaySecs": {
+                        "$numberLong": "0"
+                    },
+                    "votes": 1
+                },
+                {
+                    "_id": 2,
+                    "host": "atlas-b5vr7t-shard-00-02.mns8wfq.mongodb.net:27017",
+                    "arbiterOnly": false,
+                    "buildIndexes": true,
+                    "hidden": false,
+                    "priority": 7,
+                    "tags": {
+                        "provider": "AWS",
+                        "region": "AP_SOUTH_1",
+                        "workloadType": "OPERATIONAL",
+                        "nodeType": "ELECTABLE"
+                    },
+                    "horizons": {
+                        "MESH": "ac-xqaamls-shard-00-02.mns8wfq.mesh.mongodb.net:30432",
+                        "PRIVATE": "ac-xqaamls-shard-00-02-pri.mns8wfq.mongodb.net:27017",
+                        "PUBLIC": "ac-xqaamls-shard-00-02.mns8wfq.mongodb.net:27017"
+                    },
+                    "secondaryDelaySecs": {
+                        "$numberLong": "0"
+                    },
+                    "votes": 1
+                }
+            ],
+            "protocolVersion": {
+                "$numberLong": "1"
+            },
+            "writeConcernMajorityJournalDefault": true,
+            "settings": {
+                "chainingAllowed": false,
+                "heartbeatIntervalMillis": 2000,
+                "heartbeatTimeoutSecs": 10,
+                "electionTimeoutMillis": 10000,
+                "catchUpTimeoutMillis": -1,
+                "catchUpTakeoverDelayMillis": 30000,
+                "getLastErrorModes": {},
+                "getLastErrorDefaults": {
+                    "w": 1,
+                    "wtimeout": 0
+                },
+                "replicaSetId": {
+                    "$oid": "64e876ac8548349e68f18ecb"
+                }
+            }
+        },
+        "section": "replicaset_info",
+        "subsection": "replica_set_config",
+        "ts": {
+            "start": {
+                "$date": 1692958188922
+            },
+            "end": {
+                "$date": 1692958189009
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return rs.status();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "set": "atlas-b5vr7t-shard-0",
+            "date": {
+                "$date": 1692958189364
+            },
+            "myState": 1,
+            "term": {
+                "$numberLong": "2"
+            },
+            "syncSourceHost": {
+                "$date": 1692958193928
+            },
+            "syncSourceId": -1,
+            "heartbeatIntervalMillis": {
+                "$numberLong": "2000"
+            },
+            "majorityVoteCount": 2,
+            "writeMajorityCount": 2,
+            "votingMembersCount": 3,
+            "writableVotingMembersCount": 3,
+            "optimes": {
+                "lastCommittedOpTime": {
+                    "ts": {
+                        "$timestamp": {
+                            "t": 1692958184,
+                            "i": 1
+                        }
+                    },
+                    "t": {
+                        "$numberLong": "2"
+                    }
+                },
+                "lastCommittedWallTime": {
+                    "$date": 1692958184249
+                },
+                "readConcernMajorityOpTime": {
+                    "ts": {
+                        "$timestamp": {
+                            "t": 1692958184,
+                            "i": 1
+                        }
+                    },
+                    "t": {
+                        "$numberLong": "2"
+                    }
+                },
+                "appliedOpTime": {
+                    "ts": {
+                        "$timestamp": {
+                            "t": 1692958184,
+                            "i": 1
+                        }
+                    },
+                    "t": {
+                        "$numberLong": "2"
+                    }
+                },
+                "durableOpTime": {
+                    "ts": {
+                        "$timestamp": {
+                            "t": 1692958184,
+                            "i": 1
+                        }
+                    },
+                    "t": {
+                        "$numberLong": "2"
+                    }
+                },
+                "lastAppliedWallTime": {
+                    "$date": 1692958184249
+                },
+                "lastDurableWallTime": {
+                    "$date": 1692958184249
+                }
+            },
+            "lastStableRecoveryTimestamp": {
+                "$timestamp": {
+                    "t": 1692958144,
+                    "i": 1
+                }
+            },
+            "electionCandidateMetrics": {
+                "lastElectionReason": "priorityTakeover",
+                "lastElectionDate": {
+                    "$date": 1692956354138
+                },
+                "electionTerm": {
+                    "$numberLong": "2"
+                },
+                "lastCommittedOpTimeAtElection": {
+                    "ts": {
+                        "$timestamp": {
+                            "t": 1692956344,
+                            "i": 7
+                        }
+                    },
+                    "t": {
+                        "$numberLong": "1"
+                    }
+                },
+                "lastSeenOpTimeAtElection": {
+                    "ts": {
+                        "$timestamp": {
+                            "t": 1692956344,
+                            "i": 7
+                        }
+                    },
+                    "t": {
+                        "$numberLong": "1"
+                    }
+                },
+                "numVotesNeeded": 2,
+                "priorityAtElection": 7,
+                "electionTimeoutMillis": {
+                    "$numberLong": "10000"
+                },
+                "priorPrimaryMemberId": 0,
+                "numCatchUpOps": {
+                    "$numberLong": "0"
+                },
+                "newTermStartDate": {
+                    "$date": 1692956354202
+                },
+                "wMajorityWriteAvailabilityDate": {
+                    "$date": 1692956355217
+                }
+            },
+            "electionParticipantMetrics": {
+                "votedForCandidate": true,
+                "electionTerm": {
+                    "$numberLong": "1"
+                },
+                "lastVoteDate": {
+                    "$date": 1692956343010
+                },
+                "electionCandidateMemberId": 0,
+                "voteReason": {
+                    "$date": 1692958193928
+                },
+                "lastAppliedOpTimeAtElection": {
+                    "ts": {
+                        "$timestamp": {
+                            "t": 0,
+                            "i": 0
+                        }
+                    },
+                    "t": {
+                        "$numberLong": "-1"
+                    }
+                },
+                "maxAppliedOpTimeInSet": {
+                    "ts": {
+                        "$timestamp": {
+                            "t": 1692956332,
+                            "i": 1
+                        }
+                    },
+                    "t": {
+                        "$numberLong": "-1"
+                    }
+                },
+                "priorityAtElection": 7
+            },
+            "members": [
+                {
+                    "_id": 0,
+                    "name": "atlas-b5vr7t-shard-00-00.mns8wfq.mongodb.net:27017",
+                    "health": 1,
+                    "state": 2,
+                    "stateStr": "SECONDARY",
+                    "uptime": 1856,
+                    "optime": {
+                        "ts": {
+                            "$timestamp": {
+                                "t": 1692958184,
+                                "i": 1
+                            }
+                        },
+                        "t": {
+                            "$numberLong": "2"
+                        }
+                    },
+                    "optimeDurable": {
+                        "ts": {
+                            "$timestamp": {
+                                "t": 1692958184,
+                                "i": 1
+                            }
+                        },
+                        "t": {
+                            "$numberLong": "2"
+                        }
+                    },
+                    "optimeDate": {
+                        "$date": 1692958184000
+                    },
+                    "optimeDurableDate": {
+                        "$date": 1692958184000
+                    },
+                    "lastAppliedWallTime": {
+                        "$date": 1692958184249
+                    },
+                    "lastDurableWallTime": {
+                        "$date": 1692958184249
+                    },
+                    "lastHeartbeat": {
+                        "$date": 1692958189148
+                    },
+                    "lastHeartbeatRecv": {
+                        "$date": 1692958188166
+                    },
+                    "pingMs": {
+                        "$numberLong": "0"
+                    },
+                    "lastHeartbeatMessage": {
+                        "$date": 1692958193929
+                    },
+                    "syncSourceHost": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net:27017",
+                    "syncSourceId": 1,
+                    "infoMessage": {
+                        "$date": 1692958193929
+                    },
+                    "configVersion": 1,
+                    "configTerm": 2
+                },
+                {
+                    "_id": 1,
+                    "name": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net:27017",
+                    "health": 1,
+                    "state": 1,
+                    "stateStr": "PRIMARY",
+                    "uptime": 1861,
+                    "optime": {
+                        "ts": {
+                            "$timestamp": {
+                                "t": 1692958184,
+                                "i": 1
+                            }
+                        },
+                        "t": {
+                            "$numberLong": "2"
+                        }
+                    },
+                    "optimeDate": {
+                        "$date": 1692958184000
+                    },
+                    "lastAppliedWallTime": {
+                        "$date": 1692958184249
+                    },
+                    "lastDurableWallTime": {
+                        "$date": 1692958184249
+                    },
+                    "syncSourceHost": {
+                        "$date": 1692958193929
+                    },
+                    "syncSourceId": -1,
+                    "infoMessage": {
+                        "$date": 1692958193929
+                    },
+                    "electionTime": {
+                        "$timestamp": {
+                            "t": 1692956354,
+                            "i": 1
+                        }
+                    },
+                    "electionDate": {
+                        "$date": 1692956354000
+                    },
+                    "configVersion": 1,
+                    "configTerm": 2,
+                    "self": true,
+                    "lastHeartbeatMessage": {
+                        "$date": 1692958193929
+                    }
+                },
+                {
+                    "_id": 2,
+                    "name": "atlas-b5vr7t-shard-00-02.mns8wfq.mongodb.net:27017",
+                    "health": 1,
+                    "state": 2,
+                    "stateStr": "SECONDARY",
+                    "uptime": 1856,
+                    "optime": {
+                        "ts": {
+                            "$timestamp": {
+                                "t": 1692958184,
+                                "i": 1
+                            }
+                        },
+                        "t": {
+                            "$numberLong": "2"
+                        }
+                    },
+                    "optimeDurable": {
+                        "ts": {
+                            "$timestamp": {
+                                "t": 1692958184,
+                                "i": 1
+                            }
+                        },
+                        "t": {
+                            "$numberLong": "2"
+                        }
+                    },
+                    "optimeDate": {
+                        "$date": 1692958184000
+                    },
+                    "optimeDurableDate": {
+                        "$date": 1692958184000
+                    },
+                    "lastAppliedWallTime": {
+                        "$date": 1692958184249
+                    },
+                    "lastDurableWallTime": {
+                        "$date": 1692958184249
+                    },
+                    "lastHeartbeat": {
+                        "$date": 1692958189168
+                    },
+                    "lastHeartbeatRecv": {
+                        "$date": 1692958189201
+                    },
+                    "pingMs": {
+                        "$numberLong": "0"
+                    },
+                    "lastHeartbeatMessage": {
+                        "$date": 1692958193929
+                    },
+                    "syncSourceHost": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net:27017",
+                    "syncSourceId": 1,
+                    "infoMessage": {
+                        "$date": 1692958193929
+                    },
+                    "configVersion": 1,
+                    "configTerm": 2
+                }
+            ],
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            }
+        },
+        "section": "replicaset_info",
+        "subsection": "replica_status",
+        "ts": {
+            "start": {
+                "$date": 1692958189009
+            },
+            "end": {
+                "$date": 1692958189101
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getReplicationInfo();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "configuredLogSizeMB": 990,
+            "logSizeMB": 990,
+            "usedMB": 0.07,
+            "timeDiff": 1841,
+            "timeDiffHours": 0.51,
+            "tFirst": "Fri Aug 25 2023 15:09:03 GMT+0530 (India Standard Time)",
+            "tLast": "Fri Aug 25 2023 15:39:44 GMT+0530 (India Standard Time)",
+            "now": "Fri Aug 25 2023 15:39:49 GMT+0530 (India Standard Time)"
+        },
+        "section": "replicaset_info",
+        "subsection": "replica_info",
+        "ts": {
+            "start": {
+                "$date": 1692958189101
+            },
+            "end": {
+                "$date": 1692958189388
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.printSecondaryReplicationInfo();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "output": [],
+            "result": {
+                "source: atlas-b5vr7t-shard-00-00.mns8wfq.mongodb.net:27017": {
+                    "syncedTo": "Fri Aug 25 2023 15:39:44 GMT+0530 (India Standard Time)",
+                    "replLag": "0 secs (0 hrs) behind the primary "
+                },
+                "source: atlas-b5vr7t-shard-00-02.mns8wfq.mongodb.net:27017": {
+                    "syncedTo": "Fri Aug 25 2023 15:39:44 GMT+0530 (India Standard Time)",
+                    "replLag": "0 secs (0 hrs) behind the primary "
+                }
+            }
+        },
+        "section": "replicaset_info",
+        "subsection": "replica_slave_info",
+        "ts": {
+            "start": {
+                "$date": 1692958189389
+            },
+            "end": {
+                "$date": 1692958189556
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.system.users.countDocuments();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": 5,
+        "section": "user_auth_info",
+        "subsection": "database_user_count",
+        "ts": {
+            "start": {
+                "$date": 1692958189562
+            },
+            "end": {
+                "$date": 1692958189729
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.system.roles.countDocuments();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": 4,
+        "section": "user_auth_info",
+        "subsection": "custom_role_count",
+        "ts": {
+            "start": {
+                "$date": 1692958189729
+            },
+            "end": {
+                "$date": 1692958189803
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getMongo().getDBs();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "databases": [
+                {
+                    "name": "admin",
+                    "sizeOnDisk": {
+                        "$numberLong": "368640"
+                    },
+                    "empty": false
+                },
+                {
+                    "name": "config",
+                    "sizeOnDisk": {
+                        "$numberLong": "258048"
+                    },
+                    "empty": false
+                },
+                {
+                    "name": "local",
+                    "sizeOnDisk": {
+                        "$numberLong": "507904"
+                    },
+                    "empty": false
+                }
+            ],
+            "totalSize": {
+                "$numberLong": "1134592"
+            },
+            "totalSizeMb": {
+                "$numberLong": "1"
+            },
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            }
+        },
+        "section": "data_info",
+        "subsection": "list_of_databases",
+        "ts": {
+            "start": {
+                "$date": 1692958189803
+            },
+            "end": {
+                "$date": 1692958189878
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){ \n\t\t\t\tvar collectionNames = [] \n\t\t\t\t// Filter out views \n\t\t\t\tdb.getSiblingDB(mydb.name).getCollectionInfos({\"type\": \"collection\"}).forEach(function(collectionInfo) { \n\t\t\t\t\tcollectionNames.push(collectionInfo['name']); \n\t\t\t\t}); \n\t\t\t\t\n\t\t\t\t// Filter out the collections with the \"system.\" prefix in the system databases \n\t\t\t\tif (mydb.name == \"config\" || mydb.name == \"local\" || mydb.name == \"admin\") { \n\t\t\t\t\treturn collectionNames.filter(function (str) { return str.indexOf(\"system.\") != 0; })\n\t\t\t\t\t\t\t      .filter(function(str) { return str.indexOf(\"replset.\") != 0; }); \n\t\t\t\t} else { return collectionNames; } }",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": [],
+        "section": "data_info",
+        "subsection": "list_of_collections_for_database_'admin'",
+        "ts": {
+            "start": {
+                "$date": 1692958189878
+            },
+            "end": {
+                "$date": 1692958189957
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).stats(1024*1024);}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "db": "admin",
+            "collections": 4,
+            "views": 0,
+            "objects": 13,
+            "avgObjSize": 473.2307692307692,
+            "dataSize": 0.00586700439453125,
+            "storageSize": 0.140625,
+            "indexes": 6,
+            "indexSize": 0.2109375,
+            "totalSize": 0.3515625,
+            "scaleFactor": 1048576,
+            "fsUsedSize": 1574.1875,
+            "fsTotalSize": 10230,
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            }
+        },
+        "section": "data_info",
+        "subsection": "database_stats_(mb)",
+        "ts": {
+            "start": {
+                "$date": 1692958189958
+            },
+            "end": {
+                "$date": 1692958190033
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).getProfilingStatus();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "was": 0,
+            "slowms": 100,
+            "sampleRate": 1,
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            }
+        },
+        "section": "data_info",
+        "subsection": "database_profiler_for_database_'admin'",
+        "ts": {
+            "start": {
+                "$date": 1692958190034
+            },
+            "end": {
+                "$date": 1692958190130
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {
+            "db": "admin"
+        }
+    },
+    {
+        "command": "function(){ \n\t\t\t\tvar collectionNames = [] \n\t\t\t\t// Filter out views \n\t\t\t\tdb.getSiblingDB(mydb.name).getCollectionInfos({\"type\": \"collection\"}).forEach(function(collectionInfo) { \n\t\t\t\t\tcollectionNames.push(collectionInfo['name']); \n\t\t\t\t}); \n\t\t\t\t\n\t\t\t\t// Filter out the collections with the \"system.\" prefix in the system databases \n\t\t\t\tif (mydb.name == \"config\" || mydb.name == \"local\" || mydb.name == \"admin\") { \n\t\t\t\t\treturn collectionNames.filter(function (str) { return str.indexOf(\"system.\") != 0; })\n\t\t\t\t\t\t\t      .filter(function(str) { return str.indexOf(\"replset.\") != 0; }); \n\t\t\t\t} else { return collectionNames; } }",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": [
+            "transactions",
+            "image_collection",
+            "tenantMigrationDonors",
+            "external_validation_keys",
+            "tenantMigrationRecipients"
+        ],
+        "section": "data_info",
+        "subsection": "list_of_collections_for_database_'config'",
+        "ts": {
+            "start": {
+                "$date": 1692958190130
+            },
+            "end": {
+                "$date": 1692958190232
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).stats(1024*1024);}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "db": "config",
+            "collections": 8,
+            "views": 0,
+            "objects": 39,
+            "avgObjSize": 144,
+            "dataSize": 0.0053558349609375,
+            "storageSize": 0.078125,
+            "indexes": 12,
+            "indexSize": 0.16796875,
+            "totalSize": 0.24609375,
+            "scaleFactor": 1048576,
+            "fsUsedSize": 1574.1875,
+            "fsTotalSize": 10230,
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            }
+        },
+        "section": "data_info",
+        "subsection": "database_stats_(mb)",
+        "ts": {
+            "start": {
+                "$date": 1692958190232
+            },
+            "end": {
+                "$date": 1692958190318
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).getProfilingStatus();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "was": 0,
+            "slowms": 100,
+            "sampleRate": 1,
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            }
+        },
+        "section": "data_info",
+        "subsection": "database_profiler_for_database_'config'",
+        "ts": {
+            "start": {
+                "$date": 1692958190318
+            },
+            "end": {
+                "$date": 1692958190403
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {
+            "db": "config"
+        }
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).getCollection(col).stats(1024*1024);}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "ok": 1,
+            "capped": false,
+            "wiredTiger": {
+                "metadata": {
+                    "formatVersion": 1
+                },
+                "creationString": "access_pattern_hint=none,allocation_size=4KB,app_metadata=(formatVersion=1),assert=(commit_timestamp=none,durable_timestamp=none,read_timestamp=none,write_timestamp=off),block_allocation=best,block_compressor=snappy,cache_resident=false,checksum=on,colgroups=,collator=,columns=,dictionary=0,encryption=(keyid=,name=),exclusive=false,extractor=,format=btree,huffman_key=,huffman_value=,ignore_in_memory_cache_size=false,immutable=false,import=(compare_timestamp=oldest_timestamp,enabled=false,file_metadata=,metadata_file=,repair=false),internal_item_max=0,internal_key_max=0,internal_key_truncate=true,internal_page_max=4KB,key_format=q,key_gap=10,leaf_item_max=0,leaf_key_max=0,leaf_page_max=32KB,leaf_value_max=64MB,log=(enabled=false),lsm=(auto_throttle=true,bloom=true,bloom_bit_count=16,bloom_config=,bloom_hash_count=8,bloom_oldest=false,chunk_count_limit=0,chunk_max=5GB,chunk_size=10MB,merge_custom=(prefix=,start_generation=0,suffix=),merge_max=15,merge_min=0),memory_page_image_max=0,memory_page_max=10m,os_cache_dirty_max=0,os_cache_max=0,prefix_compression=false,prefix_compression_min=4,readonly=false,source=,split_deepen_min_child=0,split_deepen_per_child=0,split_pct=90,tiered_object=false,tiered_storage=(auth_token=,bucket=,bucket_prefix=,cache_directory=,local_retention=300,name=,object_target_size=0),type=file,value_format=u,verbose=[],write_timestamp_usage=none",
+                "type": "file",
+                "uri": "statistics:table:collection-27--4235276012238614669",
+                "LSM": {
+                    "bloom filter false positives": 0,
+                    "bloom filter hits": 0,
+                    "bloom filter misses": 0,
+                    "bloom filter pages evicted from cache": 0,
+                    "bloom filter pages read into cache": 0,
+                    "bloom filters in the LSM tree": 0,
+                    "chunks in the LSM tree": 0,
+                    "highest merge generation in the LSM tree": 0,
+                    "queries that could have benefited from a Bloom filter that did not exist": 0,
+                    "sleep for LSM checkpoint throttle": 0,
+                    "sleep for LSM merge throttle": 0,
+                    "total size of bloom filters": 0
+                },
+                "autocommit": {
+                    "retries for readonly operations": 0,
+                    "retries for update operations": 0
+                },
+                "block-manager": {
+                    "allocations requiring file extension": 4,
+                    "blocks allocated": 4,
+                    "blocks freed": 0,
+                    "checkpoint size": 4096,
+                    "file allocation unit size": 4096,
+                    "file bytes available for reuse": 0,
+                    "file magic number": 120897,
+                    "file major version number": 1,
+                    "file size in bytes": 20480,
+                    "minor version number": 0
+                },
+                "btree": {
+                    "btree checkpoint generation": 33,
+                    "btree clean tree checkpoint expiration time": {
+                        "$numberLong": "9223372036854775807"
+                    },
+                    "btree compact pages reviewed": 0,
+                    "btree compact pages rewritten": 0,
+                    "btree compact pages skipped": 0,
+                    "btree skipped by compaction as process would not reduce size": 0,
+                    "column-store fixed-size leaf pages": 0,
+                    "column-store fixed-size time windows": 0,
+                    "column-store internal pages": 0,
+                    "column-store variable-size RLE encoded values": 0,
+                    "column-store variable-size deleted values": 0,
+                    "column-store variable-size leaf pages": 0,
+                    "fixed-record size": 0,
+                    "maximum internal page size": 4096,
+                    "maximum leaf page key size": 2867,
+                    "maximum leaf page size": 32768,
+                    "maximum leaf page value size": 67108864,
+                    "maximum tree depth": 3,
+                    "number of key/value pairs": 0,
+                    "overflow pages": 0,
+                    "row-store empty values": 0,
+                    "row-store internal pages": 0,
+                    "row-store leaf pages": 0
+                },
+                "cache": {
+                    "bytes currently in the cache": 1384,
+                    "bytes dirty in the cache cumulative": 899,
+                    "bytes read into cache": 0,
+                    "bytes written from cache": 309,
+                    "checkpoint blocked page eviction": 0,
+                    "checkpoint of history store file blocked non-history store page eviction": 0,
+                    "data source pages selected for eviction unable to be evicted": 0,
+                    "eviction gave up due to detecting an out of order on disk value behind the last update on the chain": 0,
+                    "eviction gave up due to detecting an out of order tombstone ahead of the selected on disk update": 0,
+                    "eviction gave up due to detecting an out of order tombstone ahead of the selected on disk update after validating the update chain": 0,
+                    "eviction gave up due to detecting out of order timestamps on the update chain after the selected on disk update": 0,
+                    "eviction gave up due to needing to remove a record from the history store but checkpoint is running": 0,
+                    "eviction walk passes of a file": 0,
+                    "eviction walk target pages histogram - 0-9": 0,
+                    "eviction walk target pages histogram - 10-31": 0,
+                    "eviction walk target pages histogram - 128 and higher": 0,
+                    "eviction walk target pages histogram - 32-63": 0,
+                    "eviction walk target pages histogram - 64-128": 0,
+                    "eviction walk target pages reduced due to history store cache pressure": 0,
+                    "eviction walks abandoned": 0,
+                    "eviction walks gave up because they restarted their walk twice": 0,
+                    "eviction walks gave up because they saw too many pages and found no candidates": 0,
+                    "eviction walks gave up because they saw too many pages and found too few candidates": 0,
+                    "eviction walks reached end of tree": 0,
+                    "eviction walks restarted": 0,
+                    "eviction walks started from root of tree": 0,
+                    "eviction walks started from saved location in tree": 0,
+                    "hazard pointer blocked page eviction": 0,
+                    "history store table insert calls": 0,
+                    "history store table insert calls that returned restart": 0,
+                    "history store table out-of-order resolved updates that lose their durable timestamp": 0,
+                    "history store table out-of-order updates that were fixed up by reinserting with the fixed timestamp": 0,
+                    "history store table reads": 0,
+                    "history store table reads missed": 0,
+                    "history store table reads requiring squashed modifies": 0,
+                    "history store table truncation by rollback to stable to remove an unstable update": 0,
+                    "history store table truncation by rollback to stable to remove an update": 0,
+                    "history store table truncation to remove an update": 0,
+                    "history store table truncation to remove range of updates due to key being removed from the data page during reconciliation": 0,
+                    "history store table truncation to remove range of updates due to out-of-order timestamp update on data page": 0,
+                    "history store table writes requiring squashed modifies": 0,
+                    "in-memory page passed criteria to be split": 0,
+                    "in-memory page splits": 0,
+                    "internal pages evicted": 0,
+                    "internal pages split during eviction": 0,
+                    "leaf pages split during eviction": 0,
+                    "modified pages evicted": 0,
+                    "overflow pages read into cache": 0,
+                    "page split during eviction deepened the tree": 0,
+                    "page written requiring history store records": 0,
+                    "pages read into cache": 0,
+                    "pages read into cache after truncate": 1,
+                    "pages read into cache after truncate in prepare state": 0,
+                    "pages requested from the cache": 37,
+                    "pages seen by eviction walk": 0,
+                    "pages written from cache": 2,
+                    "pages written requiring in-memory restoration": 0,
+                    "the number of times full update inserted to history store": 0,
+                    "the number of times reverse modify inserted to history store": 0,
+                    "tracked dirty bytes in the cache": 0,
+                    "unmodified pages evicted": 0
+                },
+                "cache_walk": {
+                    "Average difference between current eviction generation when the page was last considered": 0,
+                    "Average on-disk page image size seen": 0,
+                    "Average time in cache for pages that have been visited by the eviction server": 0,
+                    "Average time in cache for pages that have not been visited by the eviction server": 0,
+                    "Clean pages currently in cache": 0,
+                    "Current eviction generation": 0,
+                    "Dirty pages currently in cache": 0,
+                    "Entries in the root page": 0,
+                    "Internal pages currently in cache": 0,
+                    "Leaf pages currently in cache": 0,
+                    "Maximum difference between current eviction generation when the page was last considered": 0,
+                    "Maximum page size seen": 0,
+                    "Minimum on-disk page image size seen": 0,
+                    "Number of pages never visited by eviction server": 0,
+                    "On-disk page image sizes smaller than a single allocation unit": 0,
+                    "Pages created in memory and never written": 0,
+                    "Pages currently queued for eviction": 0,
+                    "Pages that could not be queued for eviction": 0,
+                    "Refs skipped during cache traversal": 0,
+                    "Size of the root page": 0,
+                    "Total number of pages currently in cache": 0
+                },
+                "checkpoint-cleanup": {
+                    "pages added for eviction": 0,
+                    "pages removed": 0,
+                    "pages skipped during tree walk": 0,
+                    "pages visited": 1
+                },
+                "compression": {
+                    "compressed page maximum internal page size prior to compression": 4096,
+                    "compressed page maximum leaf page size prior to compression ": 131072,
+                    "compressed pages read": 0,
+                    "compressed pages written": 0,
+                    "number of blocks with compress ratio greater than 64": 0,
+                    "number of blocks with compress ratio smaller than 16": 0,
+                    "number of blocks with compress ratio smaller than 2": 0,
+                    "number of blocks with compress ratio smaller than 32": 0,
+                    "number of blocks with compress ratio smaller than 4": 0,
+                    "number of blocks with compress ratio smaller than 64": 0,
+                    "number of blocks with compress ratio smaller than 8": 0,
+                    "page written failed to compress": 0,
+                    "page written was too small to compress": 2
+                },
+                "cursor": {
+                    "Total number of entries skipped by cursor next calls": 0,
+                    "Total number of entries skipped by cursor prev calls": 0,
+                    "Total number of entries skipped to position the history store cursor": 0,
+                    "Total number of times a search near has exited due to prefix config": 0,
+                    "bulk loaded cursor insert calls": 0,
+                    "cache cursors reuse count": 36,
+                    "close calls that result in cache": 40,
+                    "create calls": 5,
+                    "cursor next calls that skip due to a globally visible history store tombstone": 0,
+                    "cursor next calls that skip greater than or equal to 100 entries": 0,
+                    "cursor next calls that skip less than 100 entries": 62,
+                    "cursor prev calls that skip due to a globally visible history store tombstone": 0,
+                    "cursor prev calls that skip greater than or equal to 100 entries": 0,
+                    "cursor prev calls that skip less than 100 entries": 1,
+                    "insert calls": 1,
+                    "insert key and value bytes": 188,
+                    "modify": 0,
+                    "modify key and value bytes affected": 0,
+                    "modify value bytes modified": 0,
+                    "next calls": 62,
+                    "open cursor count": 0,
+                    "operation restarted": 0,
+                    "prev calls": 1,
+                    "remove calls": 0,
+                    "remove key bytes removed": 0,
+                    "reserve calls": 0,
+                    "reset calls": 82,
+                    "search calls": 6,
+                    "search history store calls": 0,
+                    "search near calls": 0,
+                    "truncate calls": 0,
+                    "update calls": 0,
+                    "update key and value bytes": 0,
+                    "update value size change": 0
+                },
+                "reconciliation": {
+                    "approximate byte size of timestamps in pages written": 16,
+                    "approximate byte size of transaction IDs in pages written": 8,
+                    "dictionary matches": 0,
+                    "fast-path pages deleted": 0,
+                    "internal page key bytes discarded using suffix compression": 0,
+                    "internal page multi-block writes": 0,
+                    "leaf page key bytes discarded using prefix compression": 0,
+                    "leaf page multi-block writes": 0,
+                    "leaf-page overflow keys": 0,
+                    "maximum blocks required for a page": 1,
+                    "overflow values written": 0,
+                    "page checksum matches": 0,
+                    "page reconciliation calls": 2,
+                    "page reconciliation calls for eviction": 0,
+                    "pages deleted": 0,
+                    "pages written including an aggregated newest start durable timestamp ": 1,
+                    "pages written including an aggregated newest stop durable timestamp ": 1,
+                    "pages written including an aggregated newest stop timestamp ": 0,
+                    "pages written including an aggregated newest stop transaction ID": 0,
+                    "pages written including an aggregated newest transaction ID ": 1,
+                    "pages written including an aggregated oldest start timestamp ": 1,
+                    "pages written including an aggregated prepare": 0,
+                    "pages written including at least one prepare": 0,
+                    "pages written including at least one start durable timestamp": 1,
+                    "pages written including at least one start timestamp": 1,
+                    "pages written including at least one start transaction ID": 1,
+                    "pages written including at least one stop durable timestamp": 0,
+                    "pages written including at least one stop timestamp": 0,
+                    "pages written including at least one stop transaction ID": 0,
+                    "records written including a prepare": 0,
+                    "records written including a start durable timestamp": 1,
+                    "records written including a start timestamp": 1,
+                    "records written including a start transaction ID": 1,
+                    "records written including a stop durable timestamp": 0,
+                    "records written including a stop timestamp": 0,
+                    "records written including a stop transaction ID": 0
+                },
+                "session": {
+                    "object compaction": 0,
+                    "tiered operations dequeued and processed": 0,
+                    "tiered operations scheduled": 0,
+                    "tiered storage local retention time (secs)": 0
+                },
+                "transaction": {
+                    "checkpoint has acquired a snapshot for its transaction": 0,
+                    "race to read prepared update retry": 0,
+                    "rollback to stable history store records with stop timestamps older than newer records": 0,
+                    "rollback to stable inconsistent checkpoint": 0,
+                    "rollback to stable keys removed": 0,
+                    "rollback to stable keys restored": 0,
+                    "rollback to stable restored tombstones from history store": 0,
+                    "rollback to stable restored updates from history store": 0,
+                    "rollback to stable skipping delete rle": 0,
+                    "rollback to stable skipping stable rle": 0,
+                    "rollback to stable sweeping history store keys": 0,
+                    "rollback to stable updates removed from history store": 0,
+                    "transaction checkpoints due to obsolete pages": 0,
+                    "update conflicts": 0
+                }
+            },
+            "sharded": false,
+            "size": 0.00017833709716796875,
+            "count": 1,
+            "numOrphanDocs": 0,
+            "storageSize": 0.01953125,
+            "totalIndexSize": 0.03515625,
+            "totalSize": 0.0546875,
+            "indexSizes": {
+                "parent_lsid": 0.01171875,
+                "_id_": 0.0234375
+            },
+            "avgObjSize": 187,
+            "ns": "config.transactions",
+            "nindexes": 2,
+            "scaleFactor": 1048576
+        },
+        "section": "data_info",
+        "subsection": "collection_stats_(mb)",
+        "ts": {
+            "start": {
+                "$date": 1692958190404
+            },
+            "end": {
+                "$date": 1692958190718
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).getCollection(col).getIndexes();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": [
+            {
+                "v": 2,
+                "key": {
+                    "parentLsid": 1,
+                    "_id.txnNumber": 1,
+                    "_id": 1
+                },
+                "name": "parent_lsid",
+                "partialFilterExpression": {
+                    "parentLsid": {
+                        "$exists": true
+                    }
+                }
+            },
+            {
+                "v": 2,
+                "key": {
+                    "_id": 1
+                },
+                "name": "_id_"
+            }
+        ],
+        "section": "data_info",
+        "subsection": "indexes",
+        "ts": {
+            "start": {
+                "$date": 1692958190718
+            },
+            "end": {
+                "$date": 1692958190805
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {
+            "db": "config",
+            "collection": "transactions"
+        }
+    },
+    {
+        "command": "function(){\n\t\t\ttry {\n                                var res = db.getSiblingDB(mydb.name).runCommand( {\n                                  aggregate: col,\n                                  pipeline: [\n                                    {$indexStats: {}},\n                                    {$group: {_id: \"$key\", stats: {$push: {accesses: \"$accesses.ops\", host: \"$host\", since: \"$accesses.since\"}}}},\n                                    {$project: {key: \"$_id\", stats: 1, _id: 0}}\n                                  ],\n                                  cursor: {}\n                                });\n\t\t\t\terr=null;\n\t\t\t}catch(err) {\n\t\t\t\treturn \"Error running index stats on Database \" + mydb.name + \" Collection \" + col + \" Error: \" + err;\n\t\t\t}\n\n                                //It is assumed that there always will be a single batch as collections\n                                //are limited to 64 indexes and usage from all shards is grouped\n                                //into a single document\n\t\t\ttry {\n                                if (res.hasOwnProperty('cursor') && res.cursor.hasOwnProperty('firstBatch')) {\n                                  res.cursor.firstBatch.forEach(\n                                    function(d){\n                                      d.stats.forEach(\n                                        function(d){\n                                          d.since = d.since.toUTCString();\n                                        })\n                                    });\n                                } \n\t\t\t  err=null;\n\t\t\t} catch(err) {\n\t\t\t\treturn \"Error running index stats on Database \" + mydb.name + \" Collection \" + col + \" res processing Error: \" + err;\n\t\t\t}\n\n                                return res;\n\t\t}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "cursor": {
+                "firstBatch": [
+                    {
+                        "stats": [
+                            {
+                                "accesses": {
+                                    "$numberLong": "1"
+                                },
+                                "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net:27017",
+                                "since": "Fri, 25 Aug 2023 09:39:04 GMT"
+                            }
+                        ],
+                        "key": {
+                            "parentLsid": 1,
+                            "_id.txnNumber": 1,
+                            "_id": 1
+                        }
+                    },
+                    {
+                        "stats": [
+                            {
+                                "accesses": {
+                                    "$numberLong": "7"
+                                },
+                                "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net:27017",
+                                "since": "Fri, 25 Aug 2023 09:39:04 GMT"
+                            }
+                        ],
+                        "key": {
+                            "_id": 1
+                        }
+                    }
+                ],
+                "id": {
+                    "$numberLong": "0"
+                },
+                "ns": "config.transactions"
+            },
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            }
+        },
+        "section": "data_info",
+        "subsection": "index_stats",
+        "ts": {
+            "start": {
+                "$date": 1692958190805
+            },
+            "end": {
+                "$date": 1692958190903
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).getCollection(col).stats(1024*1024);}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "ok": 1,
+            "capped": false,
+            "wiredTiger": {
+                "metadata": {
+                    "formatVersion": 1
+                },
+                "creationString": "access_pattern_hint=none,allocation_size=4KB,app_metadata=(formatVersion=1),assert=(commit_timestamp=none,durable_timestamp=none,read_timestamp=none,write_timestamp=off),block_allocation=best,block_compressor=snappy,cache_resident=false,checksum=on,colgroups=,collator=,columns=,dictionary=0,encryption=(keyid=,name=),exclusive=false,extractor=,format=btree,huffman_key=,huffman_value=,ignore_in_memory_cache_size=false,immutable=false,import=(compare_timestamp=oldest_timestamp,enabled=false,file_metadata=,metadata_file=,repair=false),internal_item_max=0,internal_key_max=0,internal_key_truncate=true,internal_page_max=4KB,key_format=q,key_gap=10,leaf_item_max=0,leaf_key_max=0,leaf_page_max=32KB,leaf_value_max=64MB,log=(enabled=false),lsm=(auto_throttle=true,bloom=true,bloom_bit_count=16,bloom_config=,bloom_hash_count=8,bloom_oldest=false,chunk_count_limit=0,chunk_max=5GB,chunk_size=10MB,merge_custom=(prefix=,start_generation=0,suffix=),merge_max=15,merge_min=0),memory_page_image_max=0,memory_page_max=10m,os_cache_dirty_max=0,os_cache_max=0,prefix_compression=false,prefix_compression_min=4,readonly=false,source=,split_deepen_min_child=0,split_deepen_per_child=0,split_pct=90,tiered_object=false,tiered_storage=(auth_token=,bucket=,bucket_prefix=,cache_directory=,local_retention=300,name=,object_target_size=0),type=file,value_format=u,verbose=[],write_timestamp_usage=none",
+                "type": "file",
+                "uri": "statistics:table:collection-30--4235276012238614669",
+                "LSM": {
+                    "bloom filter false positives": 0,
+                    "bloom filter hits": 0,
+                    "bloom filter misses": 0,
+                    "bloom filter pages evicted from cache": 0,
+                    "bloom filter pages read into cache": 0,
+                    "bloom filters in the LSM tree": 0,
+                    "chunks in the LSM tree": 0,
+                    "highest merge generation in the LSM tree": 0,
+                    "queries that could have benefited from a Bloom filter that did not exist": 0,
+                    "sleep for LSM checkpoint throttle": 0,
+                    "sleep for LSM merge throttle": 0,
+                    "total size of bloom filters": 0
+                },
+                "autocommit": {
+                    "retries for readonly operations": 0,
+                    "retries for update operations": 0
+                },
+                "block-manager": {
+                    "allocations requiring file extension": 0,
+                    "blocks allocated": 0,
+                    "blocks freed": 0,
+                    "checkpoint size": 0,
+                    "file allocation unit size": 4096,
+                    "file bytes available for reuse": 0,
+                    "file magic number": 120897,
+                    "file major version number": 1,
+                    "file size in bytes": 4096,
+                    "minor version number": 0
+                },
+                "btree": {
+                    "btree checkpoint generation": 33,
+                    "btree clean tree checkpoint expiration time": {
+                        "$numberLong": "9223372036854775807"
+                    },
+                    "btree compact pages reviewed": 0,
+                    "btree compact pages rewritten": 0,
+                    "btree compact pages skipped": 0,
+                    "btree skipped by compaction as process would not reduce size": 0,
+                    "column-store fixed-size leaf pages": 0,
+                    "column-store fixed-size time windows": 0,
+                    "column-store internal pages": 0,
+                    "column-store variable-size RLE encoded values": 0,
+                    "column-store variable-size deleted values": 0,
+                    "column-store variable-size leaf pages": 0,
+                    "fixed-record size": 0,
+                    "maximum internal page size": 4096,
+                    "maximum leaf page key size": 2867,
+                    "maximum leaf page size": 32768,
+                    "maximum leaf page value size": 67108864,
+                    "maximum tree depth": 0,
+                    "number of key/value pairs": 0,
+                    "overflow pages": 0,
+                    "row-store empty values": 0,
+                    "row-store internal pages": 0,
+                    "row-store leaf pages": 0
+                },
+                "cache": {
+                    "bytes currently in the cache": 191,
+                    "bytes dirty in the cache cumulative": 0,
+                    "bytes read into cache": 0,
+                    "bytes written from cache": 0,
+                    "checkpoint blocked page eviction": 0,
+                    "checkpoint of history store file blocked non-history store page eviction": 0,
+                    "data source pages selected for eviction unable to be evicted": 0,
+                    "eviction gave up due to detecting an out of order on disk value behind the last update on the chain": 0,
+                    "eviction gave up due to detecting an out of order tombstone ahead of the selected on disk update": 0,
+                    "eviction gave up due to detecting an out of order tombstone ahead of the selected on disk update after validating the update chain": 0,
+                    "eviction gave up due to detecting out of order timestamps on the update chain after the selected on disk update": 0,
+                    "eviction gave up due to needing to remove a record from the history store but checkpoint is running": 0,
+                    "eviction walk passes of a file": 0,
+                    "eviction walk target pages histogram - 0-9": 0,
+                    "eviction walk target pages histogram - 10-31": 0,
+                    "eviction walk target pages histogram - 128 and higher": 0,
+                    "eviction walk target pages histogram - 32-63": 0,
+                    "eviction walk target pages histogram - 64-128": 0,
+                    "eviction walk target pages reduced due to history store cache pressure": 0,
+                    "eviction walks abandoned": 0,
+                    "eviction walks gave up because they restarted their walk twice": 0,
+                    "eviction walks gave up because they saw too many pages and found no candidates": 0,
+                    "eviction walks gave up because they saw too many pages and found too few candidates": 0,
+                    "eviction walks reached end of tree": 0,
+                    "eviction walks restarted": 0,
+                    "eviction walks started from root of tree": 0,
+                    "eviction walks started from saved location in tree": 0,
+                    "hazard pointer blocked page eviction": 0,
+                    "history store table insert calls": 0,
+                    "history store table insert calls that returned restart": 0,
+                    "history store table out-of-order resolved updates that lose their durable timestamp": 0,
+                    "history store table out-of-order updates that were fixed up by reinserting with the fixed timestamp": 0,
+                    "history store table reads": 0,
+                    "history store table reads missed": 0,
+                    "history store table reads requiring squashed modifies": 0,
+                    "history store table truncation by rollback to stable to remove an unstable update": 0,
+                    "history store table truncation by rollback to stable to remove an update": 0,
+                    "history store table truncation to remove an update": 0,
+                    "history store table truncation to remove range of updates due to key being removed from the data page during reconciliation": 0,
+                    "history store table truncation to remove range of updates due to out-of-order timestamp update on data page": 0,
+                    "history store table writes requiring squashed modifies": 0,
+                    "in-memory page passed criteria to be split": 0,
+                    "in-memory page splits": 0,
+                    "internal pages evicted": 0,
+                    "internal pages split during eviction": 0,
+                    "leaf pages split during eviction": 0,
+                    "modified pages evicted": 0,
+                    "overflow pages read into cache": 0,
+                    "page split during eviction deepened the tree": 0,
+                    "page written requiring history store records": 0,
+                    "pages read into cache": 0,
+                    "pages read into cache after truncate": 0,
+                    "pages read into cache after truncate in prepare state": 0,
+                    "pages requested from the cache": 0,
+                    "pages seen by eviction walk": 0,
+                    "pages written from cache": 0,
+                    "pages written requiring in-memory restoration": 0,
+                    "the number of times full update inserted to history store": 0,
+                    "the number of times reverse modify inserted to history store": 0,
+                    "tracked dirty bytes in the cache": 0,
+                    "unmodified pages evicted": 0
+                },
+                "cache_walk": {
+                    "Average difference between current eviction generation when the page was last considered": 0,
+                    "Average on-disk page image size seen": 0,
+                    "Average time in cache for pages that have been visited by the eviction server": 0,
+                    "Average time in cache for pages that have not been visited by the eviction server": 0,
+                    "Clean pages currently in cache": 0,
+                    "Current eviction generation": 0,
+                    "Dirty pages currently in cache": 0,
+                    "Entries in the root page": 0,
+                    "Internal pages currently in cache": 0,
+                    "Leaf pages currently in cache": 0,
+                    "Maximum difference between current eviction generation when the page was last considered": 0,
+                    "Maximum page size seen": 0,
+                    "Minimum on-disk page image size seen": 0,
+                    "Number of pages never visited by eviction server": 0,
+                    "On-disk page image sizes smaller than a single allocation unit": 0,
+                    "Pages created in memory and never written": 0,
+                    "Pages currently queued for eviction": 0,
+                    "Pages that could not be queued for eviction": 0,
+                    "Refs skipped during cache traversal": 0,
+                    "Size of the root page": 0,
+                    "Total number of pages currently in cache": 0
+                },
+                "checkpoint-cleanup": {
+                    "pages added for eviction": 0,
+                    "pages removed": 0,
+                    "pages skipped during tree walk": 0,
+                    "pages visited": 0
+                },
+                "compression": {
+                    "compressed page maximum internal page size prior to compression": 4096,
+                    "compressed page maximum leaf page size prior to compression ": 131072,
+                    "compressed pages read": 0,
+                    "compressed pages written": 0,
+                    "number of blocks with compress ratio greater than 64": 0,
+                    "number of blocks with compress ratio smaller than 16": 0,
+                    "number of blocks with compress ratio smaller than 2": 0,
+                    "number of blocks with compress ratio smaller than 32": 0,
+                    "number of blocks with compress ratio smaller than 4": 0,
+                    "number of blocks with compress ratio smaller than 64": 0,
+                    "number of blocks with compress ratio smaller than 8": 0,
+                    "page written failed to compress": 0,
+                    "page written was too small to compress": 0
+                },
+                "cursor": {
+                    "Total number of entries skipped by cursor next calls": 0,
+                    "Total number of entries skipped by cursor prev calls": 0,
+                    "Total number of entries skipped to position the history store cursor": 0,
+                    "Total number of times a search near has exited due to prefix config": 0,
+                    "bulk loaded cursor insert calls": 0,
+                    "cache cursors reuse count": 0,
+                    "close calls that result in cache": 0,
+                    "create calls": 0,
+                    "cursor next calls that skip due to a globally visible history store tombstone": 0,
+                    "cursor next calls that skip greater than or equal to 100 entries": 0,
+                    "cursor next calls that skip less than 100 entries": 0,
+                    "cursor prev calls that skip due to a globally visible history store tombstone": 0,
+                    "cursor prev calls that skip greater than or equal to 100 entries": 0,
+                    "cursor prev calls that skip less than 100 entries": 0,
+                    "insert calls": 0,
+                    "insert key and value bytes": 0,
+                    "modify": 0,
+                    "modify key and value bytes affected": 0,
+                    "modify value bytes modified": 0,
+                    "next calls": 0,
+                    "open cursor count": 0,
+                    "operation restarted": 0,
+                    "prev calls": 0,
+                    "remove calls": 0,
+                    "remove key bytes removed": 0,
+                    "reserve calls": 0,
+                    "reset calls": 0,
+                    "search calls": 0,
+                    "search history store calls": 0,
+                    "search near calls": 0,
+                    "truncate calls": 0,
+                    "update calls": 0,
+                    "update key and value bytes": 0,
+                    "update value size change": 0
+                },
+                "reconciliation": {
+                    "approximate byte size of timestamps in pages written": 0,
+                    "approximate byte size of transaction IDs in pages written": 0,
+                    "dictionary matches": 0,
+                    "fast-path pages deleted": 0,
+                    "internal page key bytes discarded using suffix compression": 0,
+                    "internal page multi-block writes": 0,
+                    "leaf page key bytes discarded using prefix compression": 0,
+                    "leaf page multi-block writes": 0,
+                    "leaf-page overflow keys": 0,
+                    "maximum blocks required for a page": 0,
+                    "overflow values written": 0,
+                    "page checksum matches": 0,
+                    "page reconciliation calls": 0,
+                    "page reconciliation calls for eviction": 0,
+                    "pages deleted": 0,
+                    "pages written including an aggregated newest start durable timestamp ": 0,
+                    "pages written including an aggregated newest stop durable timestamp ": 0,
+                    "pages written including an aggregated newest stop timestamp ": 0,
+                    "pages written including an aggregated newest stop transaction ID": 0,
+                    "pages written including an aggregated newest transaction ID ": 0,
+                    "pages written including an aggregated oldest start timestamp ": 0,
+                    "pages written including an aggregated prepare": 0,
+                    "pages written including at least one prepare": 0,
+                    "pages written including at least one start durable timestamp": 0,
+                    "pages written including at least one start timestamp": 0,
+                    "pages written including at least one start transaction ID": 0,
+                    "pages written including at least one stop durable timestamp": 0,
+                    "pages written including at least one stop timestamp": 0,
+                    "pages written including at least one stop transaction ID": 0,
+                    "records written including a prepare": 0,
+                    "records written including a start durable timestamp": 0,
+                    "records written including a start timestamp": 0,
+                    "records written including a start transaction ID": 0,
+                    "records written including a stop durable timestamp": 0,
+                    "records written including a stop timestamp": 0,
+                    "records written including a stop transaction ID": 0
+                },
+                "session": {
+                    "object compaction": 0,
+                    "tiered operations dequeued and processed": 0,
+                    "tiered operations scheduled": 0,
+                    "tiered storage local retention time (secs)": 0
+                },
+                "transaction": {
+                    "checkpoint has acquired a snapshot for its transaction": 0,
+                    "race to read prepared update retry": 0,
+                    "rollback to stable history store records with stop timestamps older than newer records": 0,
+                    "rollback to stable inconsistent checkpoint": 0,
+                    "rollback to stable keys removed": 0,
+                    "rollback to stable keys restored": 0,
+                    "rollback to stable restored tombstones from history store": 0,
+                    "rollback to stable restored updates from history store": 0,
+                    "rollback to stable skipping delete rle": 0,
+                    "rollback to stable skipping stable rle": 0,
+                    "rollback to stable sweeping history store keys": 0,
+                    "rollback to stable updates removed from history store": 0,
+                    "transaction checkpoints due to obsolete pages": 0,
+                    "update conflicts": 0
+                }
+            },
+            "sharded": false,
+            "size": 0,
+            "count": 0,
+            "numOrphanDocs": 0,
+            "storageSize": 0.00390625,
+            "totalIndexSize": 0.0078125,
+            "totalSize": 0.01171875,
+            "indexSizes": {
+                "_id_": 0.0078125
+            },
+            "avgObjSize": 0,
+            "ns": "config.image_collection",
+            "nindexes": 1,
+            "scaleFactor": 1048576
+        },
+        "section": "data_info",
+        "subsection": "collection_stats_(mb)",
+        "ts": {
+            "start": {
+                "$date": 1692958190903
+            },
+            "end": {
+                "$date": 1692958191082
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).getCollection(col).getIndexes();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": [
+            {
+                "v": 2,
+                "key": {
+                    "_id": 1
+                },
+                "name": "_id_"
+            }
+        ],
+        "section": "data_info",
+        "subsection": "indexes",
+        "ts": {
+            "start": {
+                "$date": 1692958191083
+            },
+            "end": {
+                "$date": 1692958191161
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {
+            "db": "config",
+            "collection": "image_collection"
+        }
+    },
+    {
+        "command": "function(){\n\t\t\ttry {\n                                var res = db.getSiblingDB(mydb.name).runCommand( {\n                                  aggregate: col,\n                                  pipeline: [\n                                    {$indexStats: {}},\n                                    {$group: {_id: \"$key\", stats: {$push: {accesses: \"$accesses.ops\", host: \"$host\", since: \"$accesses.since\"}}}},\n                                    {$project: {key: \"$_id\", stats: 1, _id: 0}}\n                                  ],\n                                  cursor: {}\n                                });\n\t\t\t\terr=null;\n\t\t\t}catch(err) {\n\t\t\t\treturn \"Error running index stats on Database \" + mydb.name + \" Collection \" + col + \" Error: \" + err;\n\t\t\t}\n\n                                //It is assumed that there always will be a single batch as collections\n                                //are limited to 64 indexes and usage from all shards is grouped\n                                //into a single document\n\t\t\ttry {\n                                if (res.hasOwnProperty('cursor') && res.cursor.hasOwnProperty('firstBatch')) {\n                                  res.cursor.firstBatch.forEach(\n                                    function(d){\n                                      d.stats.forEach(\n                                        function(d){\n                                          d.since = d.since.toUTCString();\n                                        })\n                                    });\n                                } \n\t\t\t  err=null;\n\t\t\t} catch(err) {\n\t\t\t\treturn \"Error running index stats on Database \" + mydb.name + \" Collection \" + col + \" res processing Error: \" + err;\n\t\t\t}\n\n                                return res;\n\t\t}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "cursor": {
+                "firstBatch": [
+                    {
+                        "stats": [
+                            {
+                                "accesses": {
+                                    "$numberLong": "0"
+                                },
+                                "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net:27017",
+                                "since": "Fri, 25 Aug 2023 09:39:04 GMT"
+                            }
+                        ],
+                        "key": {
+                            "_id": 1
+                        }
+                    }
+                ],
+                "id": {
+                    "$numberLong": "0"
+                },
+                "ns": "config.image_collection"
+            },
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            }
+        },
+        "section": "data_info",
+        "subsection": "index_stats",
+        "ts": {
+            "start": {
+                "$date": 1692958191162
+            },
+            "end": {
+                "$date": 1692958191234
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).getCollection(col).stats(1024*1024);}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "ok": 1,
+            "capped": false,
+            "wiredTiger": {
+                "metadata": {
+                    "formatVersion": 1
+                },
+                "creationString": "access_pattern_hint=none,allocation_size=4KB,app_metadata=(formatVersion=1),assert=(commit_timestamp=none,durable_timestamp=none,read_timestamp=none,write_timestamp=off),block_allocation=best,block_compressor=snappy,cache_resident=false,checksum=on,colgroups=,collator=,columns=,dictionary=0,encryption=(keyid=,name=),exclusive=false,extractor=,format=btree,huffman_key=,huffman_value=,ignore_in_memory_cache_size=false,immutable=false,import=(compare_timestamp=oldest_timestamp,enabled=false,file_metadata=,metadata_file=,repair=false),internal_item_max=0,internal_key_max=0,internal_key_truncate=true,internal_page_max=4KB,key_format=q,key_gap=10,leaf_item_max=0,leaf_key_max=0,leaf_page_max=32KB,leaf_value_max=64MB,log=(enabled=false),lsm=(auto_throttle=true,bloom=true,bloom_bit_count=16,bloom_config=,bloom_hash_count=8,bloom_oldest=false,chunk_count_limit=0,chunk_max=5GB,chunk_size=10MB,merge_custom=(prefix=,start_generation=0,suffix=),merge_max=15,merge_min=0),memory_page_image_max=0,memory_page_max=10m,os_cache_dirty_max=0,os_cache_max=0,prefix_compression=false,prefix_compression_min=4,readonly=false,source=,split_deepen_min_child=0,split_deepen_per_child=0,split_pct=90,tiered_object=false,tiered_storage=(auth_token=,bucket=,bucket_prefix=,cache_directory=,local_retention=300,name=,object_target_size=0),type=file,value_format=u,verbose=[],write_timestamp_usage=none",
+                "type": "file",
+                "uri": "statistics:table:collection-39--4235276012238614669",
+                "LSM": {
+                    "bloom filter false positives": 0,
+                    "bloom filter hits": 0,
+                    "bloom filter misses": 0,
+                    "bloom filter pages evicted from cache": 0,
+                    "bloom filter pages read into cache": 0,
+                    "bloom filters in the LSM tree": 0,
+                    "chunks in the LSM tree": 0,
+                    "highest merge generation in the LSM tree": 0,
+                    "queries that could have benefited from a Bloom filter that did not exist": 0,
+                    "sleep for LSM checkpoint throttle": 0,
+                    "sleep for LSM merge throttle": 0,
+                    "total size of bloom filters": 0
+                },
+                "autocommit": {
+                    "retries for readonly operations": 0,
+                    "retries for update operations": 0
+                },
+                "block-manager": {
+                    "allocations requiring file extension": 0,
+                    "blocks allocated": 0,
+                    "blocks freed": 0,
+                    "checkpoint size": 0,
+                    "file allocation unit size": 4096,
+                    "file bytes available for reuse": 0,
+                    "file magic number": 120897,
+                    "file major version number": 1,
+                    "file size in bytes": 4096,
+                    "minor version number": 0
+                },
+                "btree": {
+                    "btree checkpoint generation": 33,
+                    "btree clean tree checkpoint expiration time": {
+                        "$numberLong": "9223372036854775807"
+                    },
+                    "btree compact pages reviewed": 0,
+                    "btree compact pages rewritten": 0,
+                    "btree compact pages skipped": 0,
+                    "btree skipped by compaction as process would not reduce size": 0,
+                    "column-store fixed-size leaf pages": 0,
+                    "column-store fixed-size time windows": 0,
+                    "column-store internal pages": 0,
+                    "column-store variable-size RLE encoded values": 0,
+                    "column-store variable-size deleted values": 0,
+                    "column-store variable-size leaf pages": 0,
+                    "fixed-record size": 0,
+                    "maximum internal page size": 4096,
+                    "maximum leaf page key size": 2867,
+                    "maximum leaf page size": 32768,
+                    "maximum leaf page value size": 67108864,
+                    "maximum tree depth": 0,
+                    "number of key/value pairs": 0,
+                    "overflow pages": 0,
+                    "row-store empty values": 0,
+                    "row-store internal pages": 0,
+                    "row-store leaf pages": 0
+                },
+                "cache": {
+                    "bytes currently in the cache": 191,
+                    "bytes dirty in the cache cumulative": 0,
+                    "bytes read into cache": 0,
+                    "bytes written from cache": 0,
+                    "checkpoint blocked page eviction": 0,
+                    "checkpoint of history store file blocked non-history store page eviction": 0,
+                    "data source pages selected for eviction unable to be evicted": 0,
+                    "eviction gave up due to detecting an out of order on disk value behind the last update on the chain": 0,
+                    "eviction gave up due to detecting an out of order tombstone ahead of the selected on disk update": 0,
+                    "eviction gave up due to detecting an out of order tombstone ahead of the selected on disk update after validating the update chain": 0,
+                    "eviction gave up due to detecting out of order timestamps on the update chain after the selected on disk update": 0,
+                    "eviction gave up due to needing to remove a record from the history store but checkpoint is running": 0,
+                    "eviction walk passes of a file": 0,
+                    "eviction walk target pages histogram - 0-9": 0,
+                    "eviction walk target pages histogram - 10-31": 0,
+                    "eviction walk target pages histogram - 128 and higher": 0,
+                    "eviction walk target pages histogram - 32-63": 0,
+                    "eviction walk target pages histogram - 64-128": 0,
+                    "eviction walk target pages reduced due to history store cache pressure": 0,
+                    "eviction walks abandoned": 0,
+                    "eviction walks gave up because they restarted their walk twice": 0,
+                    "eviction walks gave up because they saw too many pages and found no candidates": 0,
+                    "eviction walks gave up because they saw too many pages and found too few candidates": 0,
+                    "eviction walks reached end of tree": 0,
+                    "eviction walks restarted": 0,
+                    "eviction walks started from root of tree": 0,
+                    "eviction walks started from saved location in tree": 0,
+                    "hazard pointer blocked page eviction": 0,
+                    "history store table insert calls": 0,
+                    "history store table insert calls that returned restart": 0,
+                    "history store table out-of-order resolved updates that lose their durable timestamp": 0,
+                    "history store table out-of-order updates that were fixed up by reinserting with the fixed timestamp": 0,
+                    "history store table reads": 0,
+                    "history store table reads missed": 0,
+                    "history store table reads requiring squashed modifies": 0,
+                    "history store table truncation by rollback to stable to remove an unstable update": 0,
+                    "history store table truncation by rollback to stable to remove an update": 0,
+                    "history store table truncation to remove an update": 0,
+                    "history store table truncation to remove range of updates due to key being removed from the data page during reconciliation": 0,
+                    "history store table truncation to remove range of updates due to out-of-order timestamp update on data page": 0,
+                    "history store table writes requiring squashed modifies": 0,
+                    "in-memory page passed criteria to be split": 0,
+                    "in-memory page splits": 0,
+                    "internal pages evicted": 0,
+                    "internal pages split during eviction": 0,
+                    "leaf pages split during eviction": 0,
+                    "modified pages evicted": 0,
+                    "overflow pages read into cache": 0,
+                    "page split during eviction deepened the tree": 0,
+                    "page written requiring history store records": 0,
+                    "pages read into cache": 0,
+                    "pages read into cache after truncate": 0,
+                    "pages read into cache after truncate in prepare state": 0,
+                    "pages requested from the cache": 0,
+                    "pages seen by eviction walk": 0,
+                    "pages written from cache": 0,
+                    "pages written requiring in-memory restoration": 0,
+                    "the number of times full update inserted to history store": 0,
+                    "the number of times reverse modify inserted to history store": 0,
+                    "tracked dirty bytes in the cache": 0,
+                    "unmodified pages evicted": 0
+                },
+                "cache_walk": {
+                    "Average difference between current eviction generation when the page was last considered": 0,
+                    "Average on-disk page image size seen": 0,
+                    "Average time in cache for pages that have been visited by the eviction server": 0,
+                    "Average time in cache for pages that have not been visited by the eviction server": 0,
+                    "Clean pages currently in cache": 0,
+                    "Current eviction generation": 0,
+                    "Dirty pages currently in cache": 0,
+                    "Entries in the root page": 0,
+                    "Internal pages currently in cache": 0,
+                    "Leaf pages currently in cache": 0,
+                    "Maximum difference between current eviction generation when the page was last considered": 0,
+                    "Maximum page size seen": 0,
+                    "Minimum on-disk page image size seen": 0,
+                    "Number of pages never visited by eviction server": 0,
+                    "On-disk page image sizes smaller than a single allocation unit": 0,
+                    "Pages created in memory and never written": 0,
+                    "Pages currently queued for eviction": 0,
+                    "Pages that could not be queued for eviction": 0,
+                    "Refs skipped during cache traversal": 0,
+                    "Size of the root page": 0,
+                    "Total number of pages currently in cache": 0
+                },
+                "checkpoint-cleanup": {
+                    "pages added for eviction": 0,
+                    "pages removed": 0,
+                    "pages skipped during tree walk": 0,
+                    "pages visited": 0
+                },
+                "compression": {
+                    "compressed page maximum internal page size prior to compression": 4096,
+                    "compressed page maximum leaf page size prior to compression ": 131072,
+                    "compressed pages read": 0,
+                    "compressed pages written": 0,
+                    "number of blocks with compress ratio greater than 64": 0,
+                    "number of blocks with compress ratio smaller than 16": 0,
+                    "number of blocks with compress ratio smaller than 2": 0,
+                    "number of blocks with compress ratio smaller than 32": 0,
+                    "number of blocks with compress ratio smaller than 4": 0,
+                    "number of blocks with compress ratio smaller than 64": 0,
+                    "number of blocks with compress ratio smaller than 8": 0,
+                    "page written failed to compress": 0,
+                    "page written was too small to compress": 0
+                },
+                "cursor": {
+                    "Total number of entries skipped by cursor next calls": 0,
+                    "Total number of entries skipped by cursor prev calls": 0,
+                    "Total number of entries skipped to position the history store cursor": 0,
+                    "Total number of times a search near has exited due to prefix config": 0,
+                    "bulk loaded cursor insert calls": 0,
+                    "cache cursors reuse count": 0,
+                    "close calls that result in cache": 3,
+                    "create calls": 3,
+                    "cursor next calls that skip due to a globally visible history store tombstone": 0,
+                    "cursor next calls that skip greater than or equal to 100 entries": 0,
+                    "cursor next calls that skip less than 100 entries": 3,
+                    "cursor prev calls that skip due to a globally visible history store tombstone": 0,
+                    "cursor prev calls that skip greater than or equal to 100 entries": 0,
+                    "cursor prev calls that skip less than 100 entries": 0,
+                    "insert calls": 0,
+                    "insert key and value bytes": 0,
+                    "modify": 0,
+                    "modify key and value bytes affected": 0,
+                    "modify value bytes modified": 0,
+                    "next calls": 3,
+                    "open cursor count": 0,
+                    "operation restarted": 0,
+                    "prev calls": 0,
+                    "remove calls": 0,
+                    "remove key bytes removed": 0,
+                    "reserve calls": 0,
+                    "reset calls": 6,
+                    "search calls": 0,
+                    "search history store calls": 0,
+                    "search near calls": 0,
+                    "truncate calls": 0,
+                    "update calls": 0,
+                    "update key and value bytes": 0,
+                    "update value size change": 0
+                },
+                "reconciliation": {
+                    "approximate byte size of timestamps in pages written": 0,
+                    "approximate byte size of transaction IDs in pages written": 0,
+                    "dictionary matches": 0,
+                    "fast-path pages deleted": 0,
+                    "internal page key bytes discarded using suffix compression": 0,
+                    "internal page multi-block writes": 0,
+                    "leaf page key bytes discarded using prefix compression": 0,
+                    "leaf page multi-block writes": 0,
+                    "leaf-page overflow keys": 0,
+                    "maximum blocks required for a page": 0,
+                    "overflow values written": 0,
+                    "page checksum matches": 0,
+                    "page reconciliation calls": 0,
+                    "page reconciliation calls for eviction": 0,
+                    "pages deleted": 0,
+                    "pages written including an aggregated newest start durable timestamp ": 0,
+                    "pages written including an aggregated newest stop durable timestamp ": 0,
+                    "pages written including an aggregated newest stop timestamp ": 0,
+                    "pages written including an aggregated newest stop transaction ID": 0,
+                    "pages written including an aggregated newest transaction ID ": 0,
+                    "pages written including an aggregated oldest start timestamp ": 0,
+                    "pages written including an aggregated prepare": 0,
+                    "pages written including at least one prepare": 0,
+                    "pages written including at least one start durable timestamp": 0,
+                    "pages written including at least one start timestamp": 0,
+                    "pages written including at least one start transaction ID": 0,
+                    "pages written including at least one stop durable timestamp": 0,
+                    "pages written including at least one stop timestamp": 0,
+                    "pages written including at least one stop transaction ID": 0,
+                    "records written including a prepare": 0,
+                    "records written including a start durable timestamp": 0,
+                    "records written including a start timestamp": 0,
+                    "records written including a start transaction ID": 0,
+                    "records written including a stop durable timestamp": 0,
+                    "records written including a stop timestamp": 0,
+                    "records written including a stop transaction ID": 0
+                },
+                "session": {
+                    "object compaction": 0,
+                    "tiered operations dequeued and processed": 0,
+                    "tiered operations scheduled": 0,
+                    "tiered storage local retention time (secs)": 0
+                },
+                "transaction": {
+                    "checkpoint has acquired a snapshot for its transaction": 0,
+                    "race to read prepared update retry": 0,
+                    "rollback to stable history store records with stop timestamps older than newer records": 0,
+                    "rollback to stable inconsistent checkpoint": 0,
+                    "rollback to stable keys removed": 0,
+                    "rollback to stable keys restored": 0,
+                    "rollback to stable restored tombstones from history store": 0,
+                    "rollback to stable restored updates from history store": 0,
+                    "rollback to stable skipping delete rle": 0,
+                    "rollback to stable skipping stable rle": 0,
+                    "rollback to stable sweeping history store keys": 0,
+                    "rollback to stable updates removed from history store": 0,
+                    "transaction checkpoints due to obsolete pages": 0,
+                    "update conflicts": 0
+                }
+            },
+            "sharded": false,
+            "size": 0,
+            "count": 0,
+            "numOrphanDocs": 0,
+            "storageSize": 0.00390625,
+            "totalIndexSize": 0.015625,
+            "totalSize": 0.01953125,
+            "indexSizes": {
+                "_id_": 0.00390625,
+                "TenantMigrationDonorTTLIndex": 0.01171875
+            },
+            "avgObjSize": 0,
+            "ns": "config.tenantMigrationDonors",
+            "nindexes": 2,
+            "scaleFactor": 1048576
+        },
+        "section": "data_info",
+        "subsection": "collection_stats_(mb)",
+        "ts": {
+            "start": {
+                "$date": 1692958191234
+            },
+            "end": {
+                "$date": 1692958191464
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).getCollection(col).getIndexes();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": [
+            {
+                "v": 2,
+                "key": {
+                    "_id": 1
+                },
+                "name": "_id_"
+            },
+            {
+                "v": 2,
+                "key": {
+                    "expireAt": 1
+                },
+                "name": "TenantMigrationDonorTTLIndex",
+                "expireAfterSeconds": 0
+            }
+        ],
+        "section": "data_info",
+        "subsection": "indexes",
+        "ts": {
+            "start": {
+                "$date": 1692958191465
+            },
+            "end": {
+                "$date": 1692958191558
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {
+            "db": "config",
+            "collection": "tenantMigrationDonors"
+        }
+    },
+    {
+        "command": "function(){\n\t\t\ttry {\n                                var res = db.getSiblingDB(mydb.name).runCommand( {\n                                  aggregate: col,\n                                  pipeline: [\n                                    {$indexStats: {}},\n                                    {$group: {_id: \"$key\", stats: {$push: {accesses: \"$accesses.ops\", host: \"$host\", since: \"$accesses.since\"}}}},\n                                    {$project: {key: \"$_id\", stats: 1, _id: 0}}\n                                  ],\n                                  cursor: {}\n                                });\n\t\t\t\terr=null;\n\t\t\t}catch(err) {\n\t\t\t\treturn \"Error running index stats on Database \" + mydb.name + \" Collection \" + col + \" Error: \" + err;\n\t\t\t}\n\n                                //It is assumed that there always will be a single batch as collections\n                                //are limited to 64 indexes and usage from all shards is grouped\n                                //into a single document\n\t\t\ttry {\n                                if (res.hasOwnProperty('cursor') && res.cursor.hasOwnProperty('firstBatch')) {\n                                  res.cursor.firstBatch.forEach(\n                                    function(d){\n                                      d.stats.forEach(\n                                        function(d){\n                                          d.since = d.since.toUTCString();\n                                        })\n                                    });\n                                } \n\t\t\t  err=null;\n\t\t\t} catch(err) {\n\t\t\t\treturn \"Error running index stats on Database \" + mydb.name + \" Collection \" + col + \" res processing Error: \" + err;\n\t\t\t}\n\n                                return res;\n\t\t}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "cursor": {
+                "firstBatch": [
+                    {
+                        "stats": [
+                            {
+                                "accesses": {
+                                    "$numberLong": "0"
+                                },
+                                "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net:27017",
+                                "since": "Fri, 25 Aug 2023 09:39:05 GMT"
+                            }
+                        ],
+                        "key": {
+                            "expireAt": 1
+                        }
+                    },
+                    {
+                        "stats": [
+                            {
+                                "accesses": {
+                                    "$numberLong": "0"
+                                },
+                                "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net:27017",
+                                "since": "Fri, 25 Aug 2023 09:39:05 GMT"
+                            }
+                        ],
+                        "key": {
+                            "_id": 1
+                        }
+                    }
+                ],
+                "id": {
+                    "$numberLong": "0"
+                },
+                "ns": "config.tenantMigrationDonors"
+            },
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            }
+        },
+        "section": "data_info",
+        "subsection": "index_stats",
+        "ts": {
+            "start": {
+                "$date": 1692958191558
+            },
+            "end": {
+                "$date": 1692958191639
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).getCollection(col).stats(1024*1024);}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "ok": 1,
+            "capped": false,
+            "wiredTiger": {
+                "metadata": {
+                    "formatVersion": 1
+                },
+                "creationString": "access_pattern_hint=none,allocation_size=4KB,app_metadata=(formatVersion=1),assert=(commit_timestamp=none,durable_timestamp=none,read_timestamp=none,write_timestamp=off),block_allocation=best,block_compressor=snappy,cache_resident=false,checksum=on,colgroups=,collator=,columns=,dictionary=0,encryption=(keyid=,name=),exclusive=false,extractor=,format=btree,huffman_key=,huffman_value=,ignore_in_memory_cache_size=false,immutable=false,import=(compare_timestamp=oldest_timestamp,enabled=false,file_metadata=,metadata_file=,repair=false),internal_item_max=0,internal_key_max=0,internal_key_truncate=true,internal_page_max=4KB,key_format=q,key_gap=10,leaf_item_max=0,leaf_key_max=0,leaf_page_max=32KB,leaf_value_max=64MB,log=(enabled=false),lsm=(auto_throttle=true,bloom=true,bloom_bit_count=16,bloom_config=,bloom_hash_count=8,bloom_oldest=false,chunk_count_limit=0,chunk_max=5GB,chunk_size=10MB,merge_custom=(prefix=,start_generation=0,suffix=),merge_max=15,merge_min=0),memory_page_image_max=0,memory_page_max=10m,os_cache_dirty_max=0,os_cache_max=0,prefix_compression=false,prefix_compression_min=4,readonly=false,source=,split_deepen_min_child=0,split_deepen_per_child=0,split_pct=90,tiered_object=false,tiered_storage=(auth_token=,bucket=,bucket_prefix=,cache_directory=,local_retention=300,name=,object_target_size=0),type=file,value_format=u,verbose=[],write_timestamp_usage=none",
+                "type": "file",
+                "uri": "statistics:table:collection-43--4235276012238614669",
+                "LSM": {
+                    "bloom filter false positives": 0,
+                    "bloom filter hits": 0,
+                    "bloom filter misses": 0,
+                    "bloom filter pages evicted from cache": 0,
+                    "bloom filter pages read into cache": 0,
+                    "bloom filters in the LSM tree": 0,
+                    "chunks in the LSM tree": 0,
+                    "highest merge generation in the LSM tree": 0,
+                    "queries that could have benefited from a Bloom filter that did not exist": 0,
+                    "sleep for LSM checkpoint throttle": 0,
+                    "sleep for LSM merge throttle": 0,
+                    "total size of bloom filters": 0
+                },
+                "autocommit": {
+                    "retries for readonly operations": 0,
+                    "retries for update operations": 0
+                },
+                "block-manager": {
+                    "allocations requiring file extension": 0,
+                    "blocks allocated": 0,
+                    "blocks freed": 0,
+                    "checkpoint size": 0,
+                    "file allocation unit size": 4096,
+                    "file bytes available for reuse": 0,
+                    "file magic number": 120897,
+                    "file major version number": 1,
+                    "file size in bytes": 4096,
+                    "minor version number": 0
+                },
+                "btree": {
+                    "btree checkpoint generation": 33,
+                    "btree clean tree checkpoint expiration time": {
+                        "$numberLong": "9223372036854775807"
+                    },
+                    "btree compact pages reviewed": 0,
+                    "btree compact pages rewritten": 0,
+                    "btree compact pages skipped": 0,
+                    "btree skipped by compaction as process would not reduce size": 0,
+                    "column-store fixed-size leaf pages": 0,
+                    "column-store fixed-size time windows": 0,
+                    "column-store internal pages": 0,
+                    "column-store variable-size RLE encoded values": 0,
+                    "column-store variable-size deleted values": 0,
+                    "column-store variable-size leaf pages": 0,
+                    "fixed-record size": 0,
+                    "maximum internal page size": 4096,
+                    "maximum leaf page key size": 2867,
+                    "maximum leaf page size": 32768,
+                    "maximum leaf page value size": 67108864,
+                    "maximum tree depth": 0,
+                    "number of key/value pairs": 0,
+                    "overflow pages": 0,
+                    "row-store empty values": 0,
+                    "row-store internal pages": 0,
+                    "row-store leaf pages": 0
+                },
+                "cache": {
+                    "bytes currently in the cache": 191,
+                    "bytes dirty in the cache cumulative": 0,
+                    "bytes read into cache": 0,
+                    "bytes written from cache": 0,
+                    "checkpoint blocked page eviction": 0,
+                    "checkpoint of history store file blocked non-history store page eviction": 0,
+                    "data source pages selected for eviction unable to be evicted": 0,
+                    "eviction gave up due to detecting an out of order on disk value behind the last update on the chain": 0,
+                    "eviction gave up due to detecting an out of order tombstone ahead of the selected on disk update": 0,
+                    "eviction gave up due to detecting an out of order tombstone ahead of the selected on disk update after validating the update chain": 0,
+                    "eviction gave up due to detecting out of order timestamps on the update chain after the selected on disk update": 0,
+                    "eviction gave up due to needing to remove a record from the history store but checkpoint is running": 0,
+                    "eviction walk passes of a file": 0,
+                    "eviction walk target pages histogram - 0-9": 0,
+                    "eviction walk target pages histogram - 10-31": 0,
+                    "eviction walk target pages histogram - 128 and higher": 0,
+                    "eviction walk target pages histogram - 32-63": 0,
+                    "eviction walk target pages histogram - 64-128": 0,
+                    "eviction walk target pages reduced due to history store cache pressure": 0,
+                    "eviction walks abandoned": 0,
+                    "eviction walks gave up because they restarted their walk twice": 0,
+                    "eviction walks gave up because they saw too many pages and found no candidates": 0,
+                    "eviction walks gave up because they saw too many pages and found too few candidates": 0,
+                    "eviction walks reached end of tree": 0,
+                    "eviction walks restarted": 0,
+                    "eviction walks started from root of tree": 0,
+                    "eviction walks started from saved location in tree": 0,
+                    "hazard pointer blocked page eviction": 0,
+                    "history store table insert calls": 0,
+                    "history store table insert calls that returned restart": 0,
+                    "history store table out-of-order resolved updates that lose their durable timestamp": 0,
+                    "history store table out-of-order updates that were fixed up by reinserting with the fixed timestamp": 0,
+                    "history store table reads": 0,
+                    "history store table reads missed": 0,
+                    "history store table reads requiring squashed modifies": 0,
+                    "history store table truncation by rollback to stable to remove an unstable update": 0,
+                    "history store table truncation by rollback to stable to remove an update": 0,
+                    "history store table truncation to remove an update": 0,
+                    "history store table truncation to remove range of updates due to key being removed from the data page during reconciliation": 0,
+                    "history store table truncation to remove range of updates due to out-of-order timestamp update on data page": 0,
+                    "history store table writes requiring squashed modifies": 0,
+                    "in-memory page passed criteria to be split": 0,
+                    "in-memory page splits": 0,
+                    "internal pages evicted": 0,
+                    "internal pages split during eviction": 0,
+                    "leaf pages split during eviction": 0,
+                    "modified pages evicted": 0,
+                    "overflow pages read into cache": 0,
+                    "page split during eviction deepened the tree": 0,
+                    "page written requiring history store records": 0,
+                    "pages read into cache": 0,
+                    "pages read into cache after truncate": 0,
+                    "pages read into cache after truncate in prepare state": 0,
+                    "pages requested from the cache": 0,
+                    "pages seen by eviction walk": 0,
+                    "pages written from cache": 0,
+                    "pages written requiring in-memory restoration": 0,
+                    "the number of times full update inserted to history store": 0,
+                    "the number of times reverse modify inserted to history store": 0,
+                    "tracked dirty bytes in the cache": 0,
+                    "unmodified pages evicted": 0
+                },
+                "cache_walk": {
+                    "Average difference between current eviction generation when the page was last considered": 0,
+                    "Average on-disk page image size seen": 0,
+                    "Average time in cache for pages that have been visited by the eviction server": 0,
+                    "Average time in cache for pages that have not been visited by the eviction server": 0,
+                    "Clean pages currently in cache": 0,
+                    "Current eviction generation": 0,
+                    "Dirty pages currently in cache": 0,
+                    "Entries in the root page": 0,
+                    "Internal pages currently in cache": 0,
+                    "Leaf pages currently in cache": 0,
+                    "Maximum difference between current eviction generation when the page was last considered": 0,
+                    "Maximum page size seen": 0,
+                    "Minimum on-disk page image size seen": 0,
+                    "Number of pages never visited by eviction server": 0,
+                    "On-disk page image sizes smaller than a single allocation unit": 0,
+                    "Pages created in memory and never written": 0,
+                    "Pages currently queued for eviction": 0,
+                    "Pages that could not be queued for eviction": 0,
+                    "Refs skipped during cache traversal": 0,
+                    "Size of the root page": 0,
+                    "Total number of pages currently in cache": 0
+                },
+                "checkpoint-cleanup": {
+                    "pages added for eviction": 0,
+                    "pages removed": 0,
+                    "pages skipped during tree walk": 0,
+                    "pages visited": 0
+                },
+                "compression": {
+                    "compressed page maximum internal page size prior to compression": 4096,
+                    "compressed page maximum leaf page size prior to compression ": 131072,
+                    "compressed pages read": 0,
+                    "compressed pages written": 0,
+                    "number of blocks with compress ratio greater than 64": 0,
+                    "number of blocks with compress ratio smaller than 16": 0,
+                    "number of blocks with compress ratio smaller than 2": 0,
+                    "number of blocks with compress ratio smaller than 32": 0,
+                    "number of blocks with compress ratio smaller than 4": 0,
+                    "number of blocks with compress ratio smaller than 64": 0,
+                    "number of blocks with compress ratio smaller than 8": 0,
+                    "page written failed to compress": 0,
+                    "page written was too small to compress": 0
+                },
+                "cursor": {
+                    "Total number of entries skipped by cursor next calls": 0,
+                    "Total number of entries skipped by cursor prev calls": 0,
+                    "Total number of entries skipped to position the history store cursor": 0,
+                    "Total number of times a search near has exited due to prefix config": 0,
+                    "bulk loaded cursor insert calls": 0,
+                    "cache cursors reuse count": 2,
+                    "close calls that result in cache": 4,
+                    "create calls": 2,
+                    "cursor next calls that skip due to a globally visible history store tombstone": 0,
+                    "cursor next calls that skip greater than or equal to 100 entries": 0,
+                    "cursor next calls that skip less than 100 entries": 4,
+                    "cursor prev calls that skip due to a globally visible history store tombstone": 0,
+                    "cursor prev calls that skip greater than or equal to 100 entries": 0,
+                    "cursor prev calls that skip less than 100 entries": 0,
+                    "insert calls": 0,
+                    "insert key and value bytes": 0,
+                    "modify": 0,
+                    "modify key and value bytes affected": 0,
+                    "modify value bytes modified": 0,
+                    "next calls": 4,
+                    "open cursor count": 0,
+                    "operation restarted": 0,
+                    "prev calls": 0,
+                    "remove calls": 0,
+                    "remove key bytes removed": 0,
+                    "reserve calls": 0,
+                    "reset calls": 8,
+                    "search calls": 0,
+                    "search history store calls": 0,
+                    "search near calls": 0,
+                    "truncate calls": 0,
+                    "update calls": 0,
+                    "update key and value bytes": 0,
+                    "update value size change": 0
+                },
+                "reconciliation": {
+                    "approximate byte size of timestamps in pages written": 0,
+                    "approximate byte size of transaction IDs in pages written": 0,
+                    "dictionary matches": 0,
+                    "fast-path pages deleted": 0,
+                    "internal page key bytes discarded using suffix compression": 0,
+                    "internal page multi-block writes": 0,
+                    "leaf page key bytes discarded using prefix compression": 0,
+                    "leaf page multi-block writes": 0,
+                    "leaf-page overflow keys": 0,
+                    "maximum blocks required for a page": 0,
+                    "overflow values written": 0,
+                    "page checksum matches": 0,
+                    "page reconciliation calls": 0,
+                    "page reconciliation calls for eviction": 0,
+                    "pages deleted": 0,
+                    "pages written including an aggregated newest start durable timestamp ": 0,
+                    "pages written including an aggregated newest stop durable timestamp ": 0,
+                    "pages written including an aggregated newest stop timestamp ": 0,
+                    "pages written including an aggregated newest stop transaction ID": 0,
+                    "pages written including an aggregated newest transaction ID ": 0,
+                    "pages written including an aggregated oldest start timestamp ": 0,
+                    "pages written including an aggregated prepare": 0,
+                    "pages written including at least one prepare": 0,
+                    "pages written including at least one start durable timestamp": 0,
+                    "pages written including at least one start timestamp": 0,
+                    "pages written including at least one start transaction ID": 0,
+                    "pages written including at least one stop durable timestamp": 0,
+                    "pages written including at least one stop timestamp": 0,
+                    "pages written including at least one stop transaction ID": 0,
+                    "records written including a prepare": 0,
+                    "records written including a start durable timestamp": 0,
+                    "records written including a start timestamp": 0,
+                    "records written including a start transaction ID": 0,
+                    "records written including a stop durable timestamp": 0,
+                    "records written including a stop timestamp": 0,
+                    "records written including a stop transaction ID": 0
+                },
+                "session": {
+                    "object compaction": 0,
+                    "tiered operations dequeued and processed": 0,
+                    "tiered operations scheduled": 0,
+                    "tiered storage local retention time (secs)": 0
+                },
+                "transaction": {
+                    "checkpoint has acquired a snapshot for its transaction": 0,
+                    "race to read prepared update retry": 0,
+                    "rollback to stable history store records with stop timestamps older than newer records": 0,
+                    "rollback to stable inconsistent checkpoint": 0,
+                    "rollback to stable keys removed": 0,
+                    "rollback to stable keys restored": 0,
+                    "rollback to stable restored tombstones from history store": 0,
+                    "rollback to stable restored updates from history store": 0,
+                    "rollback to stable skipping delete rle": 0,
+                    "rollback to stable skipping stable rle": 0,
+                    "rollback to stable sweeping history store keys": 0,
+                    "rollback to stable updates removed from history store": 0,
+                    "transaction checkpoints due to obsolete pages": 0,
+                    "update conflicts": 0
+                }
+            },
+            "sharded": false,
+            "size": 0,
+            "count": 0,
+            "numOrphanDocs": 0,
+            "storageSize": 0.00390625,
+            "totalIndexSize": 0.015625,
+            "totalSize": 0.01953125,
+            "indexSizes": {
+                "_id_": 0.00390625,
+                "ExternalKeysTTLIndex": 0.01171875
+            },
+            "avgObjSize": 0,
+            "ns": "config.external_validation_keys",
+            "nindexes": 2,
+            "scaleFactor": 1048576
+        },
+        "section": "data_info",
+        "subsection": "collection_stats_(mb)",
+        "ts": {
+            "start": {
+                "$date": 1692958191639
+            },
+            "end": {
+                "$date": 1692958191856
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).getCollection(col).getIndexes();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": [
+            {
+                "v": 2,
+                "key": {
+                    "_id": 1
+                },
+                "name": "_id_"
+            },
+            {
+                "v": 2,
+                "key": {
+                    "ttlExpiresAt": 1
+                },
+                "name": "ExternalKeysTTLIndex",
+                "expireAfterSeconds": 0
+            }
+        ],
+        "section": "data_info",
+        "subsection": "indexes",
+        "ts": {
+            "start": {
+                "$date": 1692958191857
+            },
+            "end": {
+                "$date": 1692958191944
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {
+            "db": "config",
+            "collection": "external_validation_keys"
+        }
+    },
+    {
+        "command": "function(){\n\t\t\ttry {\n                                var res = db.getSiblingDB(mydb.name).runCommand( {\n                                  aggregate: col,\n                                  pipeline: [\n                                    {$indexStats: {}},\n                                    {$group: {_id: \"$key\", stats: {$push: {accesses: \"$accesses.ops\", host: \"$host\", since: \"$accesses.since\"}}}},\n                                    {$project: {key: \"$_id\", stats: 1, _id: 0}}\n                                  ],\n                                  cursor: {}\n                                });\n\t\t\t\terr=null;\n\t\t\t}catch(err) {\n\t\t\t\treturn \"Error running index stats on Database \" + mydb.name + \" Collection \" + col + \" Error: \" + err;\n\t\t\t}\n\n                                //It is assumed that there always will be a single batch as collections\n                                //are limited to 64 indexes and usage from all shards is grouped\n                                //into a single document\n\t\t\ttry {\n                                if (res.hasOwnProperty('cursor') && res.cursor.hasOwnProperty('firstBatch')) {\n                                  res.cursor.firstBatch.forEach(\n                                    function(d){\n                                      d.stats.forEach(\n                                        function(d){\n                                          d.since = d.since.toUTCString();\n                                        })\n                                    });\n                                } \n\t\t\t  err=null;\n\t\t\t} catch(err) {\n\t\t\t\treturn \"Error running index stats on Database \" + mydb.name + \" Collection \" + col + \" res processing Error: \" + err;\n\t\t\t}\n\n                                return res;\n\t\t}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "cursor": {
+                "firstBatch": [
+                    {
+                        "stats": [
+                            {
+                                "accesses": {
+                                    "$numberLong": "0"
+                                },
+                                "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net:27017",
+                                "since": "Fri, 25 Aug 2023 09:39:05 GMT"
+                            }
+                        ],
+                        "key": {
+                            "ttlExpiresAt": 1
+                        }
+                    },
+                    {
+                        "stats": [
+                            {
+                                "accesses": {
+                                    "$numberLong": "0"
+                                },
+                                "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net:27017",
+                                "since": "Fri, 25 Aug 2023 09:39:05 GMT"
+                            }
+                        ],
+                        "key": {
+                            "_id": 1
+                        }
+                    }
+                ],
+                "id": {
+                    "$numberLong": "0"
+                },
+                "ns": "config.external_validation_keys"
+            },
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            }
+        },
+        "section": "data_info",
+        "subsection": "index_stats",
+        "ts": {
+            "start": {
+                "$date": 1692958191944
+            },
+            "end": {
+                "$date": 1692958192032
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).getCollection(col).stats(1024*1024);}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "ok": 1,
+            "capped": false,
+            "wiredTiger": {
+                "metadata": {
+                    "formatVersion": 1
+                },
+                "creationString": "access_pattern_hint=none,allocation_size=4KB,app_metadata=(formatVersion=1),assert=(commit_timestamp=none,durable_timestamp=none,read_timestamp=none,write_timestamp=off),block_allocation=best,block_compressor=snappy,cache_resident=false,checksum=on,colgroups=,collator=,columns=,dictionary=0,encryption=(keyid=,name=),exclusive=false,extractor=,format=btree,huffman_key=,huffman_value=,ignore_in_memory_cache_size=false,immutable=false,import=(compare_timestamp=oldest_timestamp,enabled=false,file_metadata=,metadata_file=,repair=false),internal_item_max=0,internal_key_max=0,internal_key_truncate=true,internal_page_max=4KB,key_format=q,key_gap=10,leaf_item_max=0,leaf_key_max=0,leaf_page_max=32KB,leaf_value_max=64MB,log=(enabled=false),lsm=(auto_throttle=true,bloom=true,bloom_bit_count=16,bloom_config=,bloom_hash_count=8,bloom_oldest=false,chunk_count_limit=0,chunk_max=5GB,chunk_size=10MB,merge_custom=(prefix=,start_generation=0,suffix=),merge_max=15,merge_min=0),memory_page_image_max=0,memory_page_max=10m,os_cache_dirty_max=0,os_cache_max=0,prefix_compression=false,prefix_compression_min=4,readonly=false,source=,split_deepen_min_child=0,split_deepen_per_child=0,split_pct=90,tiered_object=false,tiered_storage=(auth_token=,bucket=,bucket_prefix=,cache_directory=,local_retention=300,name=,object_target_size=0),type=file,value_format=u,verbose=[],write_timestamp_usage=none",
+                "type": "file",
+                "uri": "statistics:table:collection-37--4235276012238614669",
+                "LSM": {
+                    "bloom filter false positives": 0,
+                    "bloom filter hits": 0,
+                    "bloom filter misses": 0,
+                    "bloom filter pages evicted from cache": 0,
+                    "bloom filter pages read into cache": 0,
+                    "bloom filters in the LSM tree": 0,
+                    "chunks in the LSM tree": 0,
+                    "highest merge generation in the LSM tree": 0,
+                    "queries that could have benefited from a Bloom filter that did not exist": 0,
+                    "sleep for LSM checkpoint throttle": 0,
+                    "sleep for LSM merge throttle": 0,
+                    "total size of bloom filters": 0
+                },
+                "autocommit": {
+                    "retries for readonly operations": 0,
+                    "retries for update operations": 0
+                },
+                "block-manager": {
+                    "allocations requiring file extension": 0,
+                    "blocks allocated": 0,
+                    "blocks freed": 0,
+                    "checkpoint size": 0,
+                    "file allocation unit size": 4096,
+                    "file bytes available for reuse": 0,
+                    "file magic number": 120897,
+                    "file major version number": 1,
+                    "file size in bytes": 4096,
+                    "minor version number": 0
+                },
+                "btree": {
+                    "btree checkpoint generation": 33,
+                    "btree clean tree checkpoint expiration time": {
+                        "$numberLong": "9223372036854775807"
+                    },
+                    "btree compact pages reviewed": 0,
+                    "btree compact pages rewritten": 0,
+                    "btree compact pages skipped": 0,
+                    "btree skipped by compaction as process would not reduce size": 0,
+                    "column-store fixed-size leaf pages": 0,
+                    "column-store fixed-size time windows": 0,
+                    "column-store internal pages": 0,
+                    "column-store variable-size RLE encoded values": 0,
+                    "column-store variable-size deleted values": 0,
+                    "column-store variable-size leaf pages": 0,
+                    "fixed-record size": 0,
+                    "maximum internal page size": 4096,
+                    "maximum leaf page key size": 2867,
+                    "maximum leaf page size": 32768,
+                    "maximum leaf page value size": 67108864,
+                    "maximum tree depth": 0,
+                    "number of key/value pairs": 0,
+                    "overflow pages": 0,
+                    "row-store empty values": 0,
+                    "row-store internal pages": 0,
+                    "row-store leaf pages": 0
+                },
+                "cache": {
+                    "bytes currently in the cache": 191,
+                    "bytes dirty in the cache cumulative": 0,
+                    "bytes read into cache": 0,
+                    "bytes written from cache": 0,
+                    "checkpoint blocked page eviction": 0,
+                    "checkpoint of history store file blocked non-history store page eviction": 0,
+                    "data source pages selected for eviction unable to be evicted": 0,
+                    "eviction gave up due to detecting an out of order on disk value behind the last update on the chain": 0,
+                    "eviction gave up due to detecting an out of order tombstone ahead of the selected on disk update": 0,
+                    "eviction gave up due to detecting an out of order tombstone ahead of the selected on disk update after validating the update chain": 0,
+                    "eviction gave up due to detecting out of order timestamps on the update chain after the selected on disk update": 0,
+                    "eviction gave up due to needing to remove a record from the history store but checkpoint is running": 0,
+                    "eviction walk passes of a file": 0,
+                    "eviction walk target pages histogram - 0-9": 0,
+                    "eviction walk target pages histogram - 10-31": 0,
+                    "eviction walk target pages histogram - 128 and higher": 0,
+                    "eviction walk target pages histogram - 32-63": 0,
+                    "eviction walk target pages histogram - 64-128": 0,
+                    "eviction walk target pages reduced due to history store cache pressure": 0,
+                    "eviction walks abandoned": 0,
+                    "eviction walks gave up because they restarted their walk twice": 0,
+                    "eviction walks gave up because they saw too many pages and found no candidates": 0,
+                    "eviction walks gave up because they saw too many pages and found too few candidates": 0,
+                    "eviction walks reached end of tree": 0,
+                    "eviction walks restarted": 0,
+                    "eviction walks started from root of tree": 0,
+                    "eviction walks started from saved location in tree": 0,
+                    "hazard pointer blocked page eviction": 0,
+                    "history store table insert calls": 0,
+                    "history store table insert calls that returned restart": 0,
+                    "history store table out-of-order resolved updates that lose their durable timestamp": 0,
+                    "history store table out-of-order updates that were fixed up by reinserting with the fixed timestamp": 0,
+                    "history store table reads": 0,
+                    "history store table reads missed": 0,
+                    "history store table reads requiring squashed modifies": 0,
+                    "history store table truncation by rollback to stable to remove an unstable update": 0,
+                    "history store table truncation by rollback to stable to remove an update": 0,
+                    "history store table truncation to remove an update": 0,
+                    "history store table truncation to remove range of updates due to key being removed from the data page during reconciliation": 0,
+                    "history store table truncation to remove range of updates due to out-of-order timestamp update on data page": 0,
+                    "history store table writes requiring squashed modifies": 0,
+                    "in-memory page passed criteria to be split": 0,
+                    "in-memory page splits": 0,
+                    "internal pages evicted": 0,
+                    "internal pages split during eviction": 0,
+                    "leaf pages split during eviction": 0,
+                    "modified pages evicted": 0,
+                    "overflow pages read into cache": 0,
+                    "page split during eviction deepened the tree": 0,
+                    "page written requiring history store records": 0,
+                    "pages read into cache": 0,
+                    "pages read into cache after truncate": 0,
+                    "pages read into cache after truncate in prepare state": 0,
+                    "pages requested from the cache": 0,
+                    "pages seen by eviction walk": 0,
+                    "pages written from cache": 0,
+                    "pages written requiring in-memory restoration": 0,
+                    "the number of times full update inserted to history store": 0,
+                    "the number of times reverse modify inserted to history store": 0,
+                    "tracked dirty bytes in the cache": 0,
+                    "unmodified pages evicted": 0
+                },
+                "cache_walk": {
+                    "Average difference between current eviction generation when the page was last considered": 0,
+                    "Average on-disk page image size seen": 0,
+                    "Average time in cache for pages that have been visited by the eviction server": 0,
+                    "Average time in cache for pages that have not been visited by the eviction server": 0,
+                    "Clean pages currently in cache": 0,
+                    "Current eviction generation": 0,
+                    "Dirty pages currently in cache": 0,
+                    "Entries in the root page": 0,
+                    "Internal pages currently in cache": 0,
+                    "Leaf pages currently in cache": 0,
+                    "Maximum difference between current eviction generation when the page was last considered": 0,
+                    "Maximum page size seen": 0,
+                    "Minimum on-disk page image size seen": 0,
+                    "Number of pages never visited by eviction server": 0,
+                    "On-disk page image sizes smaller than a single allocation unit": 0,
+                    "Pages created in memory and never written": 0,
+                    "Pages currently queued for eviction": 0,
+                    "Pages that could not be queued for eviction": 0,
+                    "Refs skipped during cache traversal": 0,
+                    "Size of the root page": 0,
+                    "Total number of pages currently in cache": 0
+                },
+                "checkpoint-cleanup": {
+                    "pages added for eviction": 0,
+                    "pages removed": 0,
+                    "pages skipped during tree walk": 0,
+                    "pages visited": 0
+                },
+                "compression": {
+                    "compressed page maximum internal page size prior to compression": 4096,
+                    "compressed page maximum leaf page size prior to compression ": 131072,
+                    "compressed pages read": 0,
+                    "compressed pages written": 0,
+                    "number of blocks with compress ratio greater than 64": 0,
+                    "number of blocks with compress ratio smaller than 16": 0,
+                    "number of blocks with compress ratio smaller than 2": 0,
+                    "number of blocks with compress ratio smaller than 32": 0,
+                    "number of blocks with compress ratio smaller than 4": 0,
+                    "number of blocks with compress ratio smaller than 64": 0,
+                    "number of blocks with compress ratio smaller than 8": 0,
+                    "page written failed to compress": 0,
+                    "page written was too small to compress": 0
+                },
+                "cursor": {
+                    "Total number of entries skipped by cursor next calls": 0,
+                    "Total number of entries skipped by cursor prev calls": 0,
+                    "Total number of entries skipped to position the history store cursor": 0,
+                    "Total number of times a search near has exited due to prefix config": 0,
+                    "bulk loaded cursor insert calls": 0,
+                    "cache cursors reuse count": 0,
+                    "close calls that result in cache": 3,
+                    "create calls": 3,
+                    "cursor next calls that skip due to a globally visible history store tombstone": 0,
+                    "cursor next calls that skip greater than or equal to 100 entries": 0,
+                    "cursor next calls that skip less than 100 entries": 3,
+                    "cursor prev calls that skip due to a globally visible history store tombstone": 0,
+                    "cursor prev calls that skip greater than or equal to 100 entries": 0,
+                    "cursor prev calls that skip less than 100 entries": 0,
+                    "insert calls": 0,
+                    "insert key and value bytes": 0,
+                    "modify": 0,
+                    "modify key and value bytes affected": 0,
+                    "modify value bytes modified": 0,
+                    "next calls": 3,
+                    "open cursor count": 0,
+                    "operation restarted": 0,
+                    "prev calls": 0,
+                    "remove calls": 0,
+                    "remove key bytes removed": 0,
+                    "reserve calls": 0,
+                    "reset calls": 6,
+                    "search calls": 0,
+                    "search history store calls": 0,
+                    "search near calls": 0,
+                    "truncate calls": 0,
+                    "update calls": 0,
+                    "update key and value bytes": 0,
+                    "update value size change": 0
+                },
+                "reconciliation": {
+                    "approximate byte size of timestamps in pages written": 0,
+                    "approximate byte size of transaction IDs in pages written": 0,
+                    "dictionary matches": 0,
+                    "fast-path pages deleted": 0,
+                    "internal page key bytes discarded using suffix compression": 0,
+                    "internal page multi-block writes": 0,
+                    "leaf page key bytes discarded using prefix compression": 0,
+                    "leaf page multi-block writes": 0,
+                    "leaf-page overflow keys": 0,
+                    "maximum blocks required for a page": 0,
+                    "overflow values written": 0,
+                    "page checksum matches": 0,
+                    "page reconciliation calls": 0,
+                    "page reconciliation calls for eviction": 0,
+                    "pages deleted": 0,
+                    "pages written including an aggregated newest start durable timestamp ": 0,
+                    "pages written including an aggregated newest stop durable timestamp ": 0,
+                    "pages written including an aggregated newest stop timestamp ": 0,
+                    "pages written including an aggregated newest stop transaction ID": 0,
+                    "pages written including an aggregated newest transaction ID ": 0,
+                    "pages written including an aggregated oldest start timestamp ": 0,
+                    "pages written including an aggregated prepare": 0,
+                    "pages written including at least one prepare": 0,
+                    "pages written including at least one start durable timestamp": 0,
+                    "pages written including at least one start timestamp": 0,
+                    "pages written including at least one start transaction ID": 0,
+                    "pages written including at least one stop durable timestamp": 0,
+                    "pages written including at least one stop timestamp": 0,
+                    "pages written including at least one stop transaction ID": 0,
+                    "records written including a prepare": 0,
+                    "records written including a start durable timestamp": 0,
+                    "records written including a start timestamp": 0,
+                    "records written including a start transaction ID": 0,
+                    "records written including a stop durable timestamp": 0,
+                    "records written including a stop timestamp": 0,
+                    "records written including a stop transaction ID": 0
+                },
+                "session": {
+                    "object compaction": 0,
+                    "tiered operations dequeued and processed": 0,
+                    "tiered operations scheduled": 0,
+                    "tiered storage local retention time (secs)": 0
+                },
+                "transaction": {
+                    "checkpoint has acquired a snapshot for its transaction": 0,
+                    "race to read prepared update retry": 0,
+                    "rollback to stable history store records with stop timestamps older than newer records": 0,
+                    "rollback to stable inconsistent checkpoint": 0,
+                    "rollback to stable keys removed": 0,
+                    "rollback to stable keys restored": 0,
+                    "rollback to stable restored tombstones from history store": 0,
+                    "rollback to stable restored updates from history store": 0,
+                    "rollback to stable skipping delete rle": 0,
+                    "rollback to stable skipping stable rle": 0,
+                    "rollback to stable sweeping history store keys": 0,
+                    "rollback to stable updates removed from history store": 0,
+                    "transaction checkpoints due to obsolete pages": 0,
+                    "update conflicts": 0
+                }
+            },
+            "sharded": false,
+            "size": 0,
+            "count": 0,
+            "numOrphanDocs": 0,
+            "storageSize": 0.00390625,
+            "totalIndexSize": 0.015625,
+            "totalSize": 0.01953125,
+            "indexSizes": {
+                "_id_": 0.00390625,
+                "TenantMigrationRecipientTTLIndex": 0.01171875
+            },
+            "avgObjSize": 0,
+            "ns": "config.tenantMigrationRecipients",
+            "nindexes": 2,
+            "scaleFactor": 1048576
+        },
+        "section": "data_info",
+        "subsection": "collection_stats_(mb)",
+        "ts": {
+            "start": {
+                "$date": 1692958192032
+            },
+            "end": {
+                "$date": 1692958192227
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).getCollection(col).getIndexes();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": [
+            {
+                "v": 2,
+                "key": {
+                    "_id": 1
+                },
+                "name": "_id_"
+            },
+            {
+                "v": 2,
+                "key": {
+                    "expireAt": 1
+                },
+                "name": "TenantMigrationRecipientTTLIndex",
+                "expireAfterSeconds": 0
+            }
+        ],
+        "section": "data_info",
+        "subsection": "indexes",
+        "ts": {
+            "start": {
+                "$date": 1692958192227
+            },
+            "end": {
+                "$date": 1692958192321
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {
+            "db": "config",
+            "collection": "tenantMigrationRecipients"
+        }
+    },
+    {
+        "command": "function(){\n\t\t\ttry {\n                                var res = db.getSiblingDB(mydb.name).runCommand( {\n                                  aggregate: col,\n                                  pipeline: [\n                                    {$indexStats: {}},\n                                    {$group: {_id: \"$key\", stats: {$push: {accesses: \"$accesses.ops\", host: \"$host\", since: \"$accesses.since\"}}}},\n                                    {$project: {key: \"$_id\", stats: 1, _id: 0}}\n                                  ],\n                                  cursor: {}\n                                });\n\t\t\t\terr=null;\n\t\t\t}catch(err) {\n\t\t\t\treturn \"Error running index stats on Database \" + mydb.name + \" Collection \" + col + \" Error: \" + err;\n\t\t\t}\n\n                                //It is assumed that there always will be a single batch as collections\n                                //are limited to 64 indexes and usage from all shards is grouped\n                                //into a single document\n\t\t\ttry {\n                                if (res.hasOwnProperty('cursor') && res.cursor.hasOwnProperty('firstBatch')) {\n                                  res.cursor.firstBatch.forEach(\n                                    function(d){\n                                      d.stats.forEach(\n                                        function(d){\n                                          d.since = d.since.toUTCString();\n                                        })\n                                    });\n                                } \n\t\t\t  err=null;\n\t\t\t} catch(err) {\n\t\t\t\treturn \"Error running index stats on Database \" + mydb.name + \" Collection \" + col + \" res processing Error: \" + err;\n\t\t\t}\n\n                                return res;\n\t\t}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "cursor": {
+                "firstBatch": [
+                    {
+                        "stats": [
+                            {
+                                "accesses": {
+                                    "$numberLong": "0"
+                                },
+                                "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net:27017",
+                                "since": "Fri, 25 Aug 2023 09:39:05 GMT"
+                            }
+                        ],
+                        "key": {
+                            "expireAt": 1
+                        }
+                    },
+                    {
+                        "stats": [
+                            {
+                                "accesses": {
+                                    "$numberLong": "0"
+                                },
+                                "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net:27017",
+                                "since": "Fri, 25 Aug 2023 09:39:05 GMT"
+                            }
+                        ],
+                        "key": {
+                            "_id": 1
+                        }
+                    }
+                ],
+                "id": {
+                    "$numberLong": "0"
+                },
+                "ns": "config.tenantMigrationRecipients"
+            },
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            }
+        },
+        "section": "data_info",
+        "subsection": "index_stats",
+        "ts": {
+            "start": {
+                "$date": 1692958192321
+            },
+            "end": {
+                "$date": 1692958192393
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){ \n\t\t\t\tvar collectionNames = [] \n\t\t\t\t// Filter out views \n\t\t\t\tdb.getSiblingDB(mydb.name).getCollectionInfos({\"type\": \"collection\"}).forEach(function(collectionInfo) { \n\t\t\t\t\tcollectionNames.push(collectionInfo['name']); \n\t\t\t\t}); \n\t\t\t\t\n\t\t\t\t// Filter out the collections with the \"system.\" prefix in the system databases \n\t\t\t\tif (mydb.name == \"config\" || mydb.name == \"local\" || mydb.name == \"admin\") { \n\t\t\t\t\treturn collectionNames.filter(function (str) { return str.indexOf(\"system.\") != 0; })\n\t\t\t\t\t\t\t      .filter(function(str) { return str.indexOf(\"replset.\") != 0; }); \n\t\t\t\t} else { return collectionNames; } }",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": [
+            "clustermanager",
+            "startup_log",
+            "oplog.rs"
+        ],
+        "section": "data_info",
+        "subsection": "list_of_collections_for_database_'local'",
+        "ts": {
+            "start": {
+                "$date": 1692958192393
+            },
+            "end": {
+                "$date": 1692958192477
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).stats(1024*1024);}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "db": "local",
+            "collections": 10,
+            "views": 1,
+            "objects": 345,
+            "avgObjSize": 219.7014492753623,
+            "dataSize": 0.07228565216064453,
+            "storageSize": 0.30859375,
+            "indexes": 9,
+            "indexSize": 0.17578125,
+            "totalSize": 0.484375,
+            "scaleFactor": 1048576,
+            "fsUsedSize": 1574.19140625,
+            "fsTotalSize": 10230,
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            }
+        },
+        "section": "data_info",
+        "subsection": "database_stats_(mb)",
+        "ts": {
+            "start": {
+                "$date": 1692958192477
+            },
+            "end": {
+                "$date": 1692958192564
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).getProfilingStatus();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "was": 0,
+            "slowms": 100,
+            "sampleRate": 1,
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            }
+        },
+        "section": "data_info",
+        "subsection": "database_profiler_for_database_'local'",
+        "ts": {
+            "start": {
+                "$date": 1692958192564
+            },
+            "end": {
+                "$date": 1692958192664
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {
+            "db": "local"
+        }
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).getCollection(col).stats(1024*1024);}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "ok": 1,
+            "capped": false,
+            "wiredTiger": {
+                "metadata": {
+                    "formatVersion": 1
+                },
+                "creationString": "access_pattern_hint=none,allocation_size=4KB,app_metadata=(formatVersion=1),assert=(commit_timestamp=none,durable_timestamp=none,read_timestamp=none,write_timestamp=off),block_allocation=best,block_compressor=snappy,cache_resident=false,checksum=on,colgroups=,collator=,columns=,dictionary=0,encryption=(keyid=,name=),exclusive=false,extractor=,format=btree,huffman_key=,huffman_value=,ignore_in_memory_cache_size=false,immutable=false,import=(compare_timestamp=oldest_timestamp,enabled=false,file_metadata=,metadata_file=,repair=false),internal_item_max=0,internal_key_max=0,internal_key_truncate=true,internal_page_max=4KB,key_format=q,key_gap=10,leaf_item_max=0,leaf_key_max=0,leaf_page_max=32KB,leaf_value_max=64MB,log=(enabled=true),lsm=(auto_throttle=true,bloom=true,bloom_bit_count=16,bloom_config=,bloom_hash_count=8,bloom_oldest=false,chunk_count_limit=0,chunk_max=5GB,chunk_size=10MB,merge_custom=(prefix=,start_generation=0,suffix=),merge_max=15,merge_min=0),memory_page_image_max=0,memory_page_max=10m,os_cache_dirty_max=0,os_cache_max=0,prefix_compression=false,prefix_compression_min=4,readonly=false,source=,split_deepen_min_child=0,split_deepen_per_child=0,split_pct=90,tiered_object=false,tiered_storage=(auth_token=,bucket=,bucket_prefix=,cache_directory=,local_retention=300,name=,object_target_size=0),type=file,value_format=u,verbose=[],write_timestamp_usage=none",
+                "type": "file",
+                "uri": "statistics:table:collection-12--4235276012238614669",
+                "LSM": {
+                    "bloom filter false positives": 0,
+                    "bloom filter hits": 0,
+                    "bloom filter misses": 0,
+                    "bloom filter pages evicted from cache": 0,
+                    "bloom filter pages read into cache": 0,
+                    "bloom filters in the LSM tree": 0,
+                    "chunks in the LSM tree": 0,
+                    "highest merge generation in the LSM tree": 0,
+                    "queries that could have benefited from a Bloom filter that did not exist": 0,
+                    "sleep for LSM checkpoint throttle": 0,
+                    "sleep for LSM merge throttle": 0,
+                    "total size of bloom filters": 0
+                },
+                "autocommit": {
+                    "retries for readonly operations": 0,
+                    "retries for update operations": 0
+                },
+                "block-manager": {
+                    "allocations requiring file extension": 8,
+                    "blocks allocated": 12,
+                    "blocks freed": 2,
+                    "checkpoint size": 4096,
+                    "file allocation unit size": 4096,
+                    "file bytes available for reuse": 16384,
+                    "file magic number": 120897,
+                    "file major version number": 1,
+                    "file size in bytes": 36864,
+                    "minor version number": 0
+                },
+                "btree": {
+                    "btree checkpoint generation": 33,
+                    "btree clean tree checkpoint expiration time": {
+                        "$numberLong": "9223372036854775807"
+                    },
+                    "btree compact pages reviewed": 0,
+                    "btree compact pages rewritten": 0,
+                    "btree compact pages skipped": 0,
+                    "btree skipped by compaction as process would not reduce size": 0,
+                    "column-store fixed-size leaf pages": 0,
+                    "column-store fixed-size time windows": 0,
+                    "column-store internal pages": 0,
+                    "column-store variable-size RLE encoded values": 0,
+                    "column-store variable-size deleted values": 0,
+                    "column-store variable-size leaf pages": 0,
+                    "fixed-record size": 0,
+                    "maximum internal page size": 4096,
+                    "maximum leaf page key size": 2867,
+                    "maximum leaf page size": 32768,
+                    "maximum leaf page value size": 67108864,
+                    "maximum tree depth": 3,
+                    "number of key/value pairs": 0,
+                    "overflow pages": 0,
+                    "row-store empty values": 0,
+                    "row-store internal pages": 0,
+                    "row-store leaf pages": 0
+                },
+                "cache": {
+                    "bytes currently in the cache": 2179,
+                    "bytes dirty in the cache cumulative": 4256,
+                    "bytes read into cache": 0,
+                    "bytes written from cache": 726,
+                    "checkpoint blocked page eviction": 0,
+                    "checkpoint of history store file blocked non-history store page eviction": 0,
+                    "data source pages selected for eviction unable to be evicted": 0,
+                    "eviction gave up due to detecting an out of order on disk value behind the last update on the chain": 0,
+                    "eviction gave up due to detecting an out of order tombstone ahead of the selected on disk update": 0,
+                    "eviction gave up due to detecting an out of order tombstone ahead of the selected on disk update after validating the update chain": 0,
+                    "eviction gave up due to detecting out of order timestamps on the update chain after the selected on disk update": 0,
+                    "eviction gave up due to needing to remove a record from the history store but checkpoint is running": 0,
+                    "eviction walk passes of a file": 0,
+                    "eviction walk target pages histogram - 0-9": 0,
+                    "eviction walk target pages histogram - 10-31": 0,
+                    "eviction walk target pages histogram - 128 and higher": 0,
+                    "eviction walk target pages histogram - 32-63": 0,
+                    "eviction walk target pages histogram - 64-128": 0,
+                    "eviction walk target pages reduced due to history store cache pressure": 0,
+                    "eviction walks abandoned": 0,
+                    "eviction walks gave up because they restarted their walk twice": 0,
+                    "eviction walks gave up because they saw too many pages and found no candidates": 0,
+                    "eviction walks gave up because they saw too many pages and found too few candidates": 0,
+                    "eviction walks reached end of tree": 0,
+                    "eviction walks restarted": 0,
+                    "eviction walks started from root of tree": 0,
+                    "eviction walks started from saved location in tree": 0,
+                    "hazard pointer blocked page eviction": 0,
+                    "history store table insert calls": 0,
+                    "history store table insert calls that returned restart": 0,
+                    "history store table out-of-order resolved updates that lose their durable timestamp": 0,
+                    "history store table out-of-order updates that were fixed up by reinserting with the fixed timestamp": 0,
+                    "history store table reads": 0,
+                    "history store table reads missed": 0,
+                    "history store table reads requiring squashed modifies": 0,
+                    "history store table truncation by rollback to stable to remove an unstable update": 0,
+                    "history store table truncation by rollback to stable to remove an update": 0,
+                    "history store table truncation to remove an update": 0,
+                    "history store table truncation to remove range of updates due to key being removed from the data page during reconciliation": 0,
+                    "history store table truncation to remove range of updates due to out-of-order timestamp update on data page": 0,
+                    "history store table writes requiring squashed modifies": 0,
+                    "in-memory page passed criteria to be split": 0,
+                    "in-memory page splits": 0,
+                    "internal pages evicted": 0,
+                    "internal pages split during eviction": 0,
+                    "leaf pages split during eviction": 0,
+                    "modified pages evicted": 0,
+                    "overflow pages read into cache": 0,
+                    "page split during eviction deepened the tree": 0,
+                    "page written requiring history store records": 0,
+                    "pages read into cache": 0,
+                    "pages read into cache after truncate": 1,
+                    "pages read into cache after truncate in prepare state": 0,
+                    "pages requested from the cache": 371,
+                    "pages seen by eviction walk": 0,
+                    "pages written from cache": 6,
+                    "pages written requiring in-memory restoration": 0,
+                    "the number of times full update inserted to history store": 0,
+                    "the number of times reverse modify inserted to history store": 0,
+                    "tracked dirty bytes in the cache": 0,
+                    "unmodified pages evicted": 0
+                },
+                "cache_walk": {
+                    "Average difference between current eviction generation when the page was last considered": 0,
+                    "Average on-disk page image size seen": 0,
+                    "Average time in cache for pages that have been visited by the eviction server": 0,
+                    "Average time in cache for pages that have not been visited by the eviction server": 0,
+                    "Clean pages currently in cache": 0,
+                    "Current eviction generation": 0,
+                    "Dirty pages currently in cache": 0,
+                    "Entries in the root page": 0,
+                    "Internal pages currently in cache": 0,
+                    "Leaf pages currently in cache": 0,
+                    "Maximum difference between current eviction generation when the page was last considered": 0,
+                    "Maximum page size seen": 0,
+                    "Minimum on-disk page image size seen": 0,
+                    "Number of pages never visited by eviction server": 0,
+                    "On-disk page image sizes smaller than a single allocation unit": 0,
+                    "Pages created in memory and never written": 0,
+                    "Pages currently queued for eviction": 0,
+                    "Pages that could not be queued for eviction": 0,
+                    "Refs skipped during cache traversal": 0,
+                    "Size of the root page": 0,
+                    "Total number of pages currently in cache": 0
+                },
+                "checkpoint-cleanup": {
+                    "pages added for eviction": 0,
+                    "pages removed": 0,
+                    "pages skipped during tree walk": 0,
+                    "pages visited": 3
+                },
+                "compression": {
+                    "compressed page maximum internal page size prior to compression": 4096,
+                    "compressed page maximum leaf page size prior to compression ": 131072,
+                    "compressed pages read": 0,
+                    "compressed pages written": 0,
+                    "number of blocks with compress ratio greater than 64": 0,
+                    "number of blocks with compress ratio smaller than 16": 0,
+                    "number of blocks with compress ratio smaller than 2": 0,
+                    "number of blocks with compress ratio smaller than 32": 0,
+                    "number of blocks with compress ratio smaller than 4": 0,
+                    "number of blocks with compress ratio smaller than 64": 0,
+                    "number of blocks with compress ratio smaller than 8": 0,
+                    "page written failed to compress": 0,
+                    "page written was too small to compress": 6
+                },
+                "cursor": {
+                    "Total number of entries skipped by cursor next calls": 0,
+                    "Total number of entries skipped by cursor prev calls": 0,
+                    "Total number of entries skipped to position the history store cursor": 0,
+                    "Total number of times a search near has exited due to prefix config": 0,
+                    "bulk loaded cursor insert calls": 0,
+                    "cache cursors reuse count": 254,
+                    "close calls that result in cache": 261,
+                    "create calls": 8,
+                    "cursor next calls that skip due to a globally visible history store tombstone": 0,
+                    "cursor next calls that skip greater than or equal to 100 entries": 0,
+                    "cursor next calls that skip less than 100 entries": 250,
+                    "cursor prev calls that skip due to a globally visible history store tombstone": 0,
+                    "cursor prev calls that skip greater than or equal to 100 entries": 0,
+                    "cursor prev calls that skip less than 100 entries": 1,
+                    "insert calls": 4,
+                    "insert key and value bytes": 405,
+                    "modify": 8,
+                    "modify key and value bytes affected": 1216,
+                    "modify value bytes modified": 64,
+                    "next calls": 250,
+                    "open cursor count": 0,
+                    "operation restarted": 0,
+                    "prev calls": 1,
+                    "remove calls": 0,
+                    "remove key bytes removed": 0,
+                    "reserve calls": 0,
+                    "reset calls": 633,
+                    "search calls": 11,
+                    "search history store calls": 0,
+                    "search near calls": 108,
+                    "truncate calls": 0,
+                    "update calls": 0,
+                    "update key and value bytes": 0,
+                    "update value size change": 0
+                },
+                "reconciliation": {
+                    "approximate byte size of timestamps in pages written": 0,
+                    "approximate byte size of transaction IDs in pages written": 0,
+                    "dictionary matches": 0,
+                    "fast-path pages deleted": 0,
+                    "internal page key bytes discarded using suffix compression": 0,
+                    "internal page multi-block writes": 0,
+                    "leaf page key bytes discarded using prefix compression": 0,
+                    "leaf page multi-block writes": 0,
+                    "leaf-page overflow keys": 0,
+                    "maximum blocks required for a page": 1,
+                    "overflow values written": 0,
+                    "page checksum matches": 0,
+                    "page reconciliation calls": 6,
+                    "page reconciliation calls for eviction": 0,
+                    "pages deleted": 0,
+                    "pages written including an aggregated newest start durable timestamp ": 0,
+                    "pages written including an aggregated newest stop durable timestamp ": 0,
+                    "pages written including an aggregated newest stop timestamp ": 0,
+                    "pages written including an aggregated newest stop transaction ID": 0,
+                    "pages written including an aggregated newest transaction ID ": 0,
+                    "pages written including an aggregated oldest start timestamp ": 0,
+                    "pages written including an aggregated prepare": 0,
+                    "pages written including at least one prepare": 0,
+                    "pages written including at least one start durable timestamp": 0,
+                    "pages written including at least one start timestamp": 0,
+                    "pages written including at least one start transaction ID": 0,
+                    "pages written including at least one stop durable timestamp": 0,
+                    "pages written including at least one stop timestamp": 0,
+                    "pages written including at least one stop transaction ID": 0,
+                    "records written including a prepare": 0,
+                    "records written including a start durable timestamp": 0,
+                    "records written including a start timestamp": 0,
+                    "records written including a start transaction ID": 0,
+                    "records written including a stop durable timestamp": 0,
+                    "records written including a stop timestamp": 0,
+                    "records written including a stop transaction ID": 0
+                },
+                "session": {
+                    "object compaction": 0,
+                    "tiered operations dequeued and processed": 0,
+                    "tiered operations scheduled": 0,
+                    "tiered storage local retention time (secs)": 0
+                },
+                "transaction": {
+                    "checkpoint has acquired a snapshot for its transaction": 0,
+                    "race to read prepared update retry": 0,
+                    "rollback to stable history store records with stop timestamps older than newer records": 0,
+                    "rollback to stable inconsistent checkpoint": 0,
+                    "rollback to stable keys removed": 0,
+                    "rollback to stable keys restored": 0,
+                    "rollback to stable restored tombstones from history store": 0,
+                    "rollback to stable restored updates from history store": 0,
+                    "rollback to stable skipping delete rle": 0,
+                    "rollback to stable skipping stable rle": 0,
+                    "rollback to stable sweeping history store keys": 0,
+                    "rollback to stable updates removed from history store": 0,
+                    "transaction checkpoints due to obsolete pages": 0,
+                    "update conflicts": 0
+                }
+            },
+            "sharded": false,
+            "size": 0.00014495849609375,
+            "count": 1,
+            "numOrphanDocs": 0,
+            "storageSize": 0.03515625,
+            "totalIndexSize": 0.01953125,
+            "totalSize": 0.0546875,
+            "indexSizes": {
+                "_id_": 0.01953125
+            },
+            "avgObjSize": 152,
+            "ns": "local.clustermanager",
+            "nindexes": 1,
+            "scaleFactor": 1048576
+        },
+        "section": "data_info",
+        "subsection": "collection_stats_(mb)",
+        "ts": {
+            "start": {
+                "$date": 1692958192664
+            },
+            "end": {
+                "$date": 1692958192865
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).getCollection(col).getIndexes();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": [
+            {
+                "v": 2,
+                "key": {
+                    "_id": 1
+                },
+                "name": "_id_"
+            }
+        ],
+        "section": "data_info",
+        "subsection": "indexes",
+        "ts": {
+            "start": {
+                "$date": 1692958192865
+            },
+            "end": {
+                "$date": 1692958192971
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {
+            "db": "local",
+            "collection": "clustermanager"
+        }
+    },
+    {
+        "command": "function(){\n\t\t\ttry {\n                                var res = db.getSiblingDB(mydb.name).runCommand( {\n                                  aggregate: col,\n                                  pipeline: [\n                                    {$indexStats: {}},\n                                    {$group: {_id: \"$key\", stats: {$push: {accesses: \"$accesses.ops\", host: \"$host\", since: \"$accesses.since\"}}}},\n                                    {$project: {key: \"$_id\", stats: 1, _id: 0}}\n                                  ],\n                                  cursor: {}\n                                });\n\t\t\t\terr=null;\n\t\t\t}catch(err) {\n\t\t\t\treturn \"Error running index stats on Database \" + mydb.name + \" Collection \" + col + \" Error: \" + err;\n\t\t\t}\n\n                                //It is assumed that there always will be a single batch as collections\n                                //are limited to 64 indexes and usage from all shards is grouped\n                                //into a single document\n\t\t\ttry {\n                                if (res.hasOwnProperty('cursor') && res.cursor.hasOwnProperty('firstBatch')) {\n                                  res.cursor.firstBatch.forEach(\n                                    function(d){\n                                      d.stats.forEach(\n                                        function(d){\n                                          d.since = d.since.toUTCString();\n                                        })\n                                    });\n                                } \n\t\t\t  err=null;\n\t\t\t} catch(err) {\n\t\t\t\treturn \"Error running index stats on Database \" + mydb.name + \" Collection \" + col + \" res processing Error: \" + err;\n\t\t\t}\n\n                                return res;\n\t\t}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "cursor": {
+                "firstBatch": [
+                    {
+                        "stats": [
+                            {
+                                "accesses": {
+                                    "$numberLong": "0"
+                                },
+                                "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net:27017",
+                                "since": "Fri, 25 Aug 2023 09:38:49 GMT"
+                            }
+                        ],
+                        "key": {
+                            "_id": 1
+                        }
+                    }
+                ],
+                "id": {
+                    "$numberLong": "0"
+                },
+                "ns": "local.clustermanager"
+            },
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            }
+        },
+        "section": "data_info",
+        "subsection": "index_stats",
+        "ts": {
+            "start": {
+                "$date": 1692958192972
+            },
+            "end": {
+                "$date": 1692958193184
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).getCollection(col).stats(1024*1024);}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "ok": 1,
+            "capped": true,
+            "max": 0,
+            "wiredTiger": {
+                "metadata": {
+                    "formatVersion": 1
+                },
+                "creationString": "access_pattern_hint=none,allocation_size=4KB,app_metadata=(formatVersion=1),assert=(commit_timestamp=none,durable_timestamp=none,read_timestamp=none,write_timestamp=off),block_allocation=best,block_compressor=snappy,cache_resident=false,checksum=on,colgroups=,collator=,columns=,dictionary=0,encryption=(keyid=,name=),exclusive=false,extractor=,format=btree,huffman_key=,huffman_value=,ignore_in_memory_cache_size=false,immutable=false,import=(compare_timestamp=oldest_timestamp,enabled=false,file_metadata=,metadata_file=,repair=false),internal_item_max=0,internal_key_max=0,internal_key_truncate=true,internal_page_max=4KB,key_format=q,key_gap=10,leaf_item_max=0,leaf_key_max=0,leaf_page_max=32KB,leaf_value_max=64MB,log=(enabled=true),lsm=(auto_throttle=true,bloom=true,bloom_bit_count=16,bloom_config=,bloom_hash_count=8,bloom_oldest=false,chunk_count_limit=0,chunk_max=5GB,chunk_size=10MB,merge_custom=(prefix=,start_generation=0,suffix=),merge_max=15,merge_min=0),memory_page_image_max=0,memory_page_max=10m,os_cache_dirty_max=0,os_cache_max=0,prefix_compression=false,prefix_compression_min=4,readonly=false,source=,split_deepen_min_child=0,split_deepen_per_child=0,split_pct=90,tiered_object=false,tiered_storage=(auth_token=,bucket=,bucket_prefix=,cache_directory=,local_retention=300,name=,object_target_size=0),type=file,value_format=u,verbose=[],write_timestamp_usage=none",
+                "type": "file",
+                "uri": "statistics:table:collection-0--4235276012238614669",
+                "LSM": {
+                    "bloom filter false positives": 0,
+                    "bloom filter hits": 0,
+                    "bloom filter misses": 0,
+                    "bloom filter pages evicted from cache": 0,
+                    "bloom filter pages read into cache": 0,
+                    "bloom filters in the LSM tree": 0,
+                    "chunks in the LSM tree": 0,
+                    "highest merge generation in the LSM tree": 0,
+                    "queries that could have benefited from a Bloom filter that did not exist": 0,
+                    "sleep for LSM checkpoint throttle": 0,
+                    "sleep for LSM merge throttle": 0,
+                    "total size of bloom filters": 0
+                },
+                "autocommit": {
+                    "retries for readonly operations": 0,
+                    "retries for update operations": 0
+                },
+                "block-manager": {
+                    "allocations requiring file extension": 4,
+                    "blocks allocated": 4,
+                    "blocks freed": 0,
+                    "checkpoint size": 4096,
+                    "file allocation unit size": 4096,
+                    "file bytes available for reuse": 0,
+                    "file magic number": 120897,
+                    "file major version number": 1,
+                    "file size in bytes": 20480,
+                    "minor version number": 0
+                },
+                "btree": {
+                    "btree checkpoint generation": 33,
+                    "btree clean tree checkpoint expiration time": {
+                        "$numberLong": "9223372036854775807"
+                    },
+                    "btree compact pages reviewed": 0,
+                    "btree compact pages rewritten": 0,
+                    "btree compact pages skipped": 0,
+                    "btree skipped by compaction as process would not reduce size": 0,
+                    "column-store fixed-size leaf pages": 0,
+                    "column-store fixed-size time windows": 0,
+                    "column-store internal pages": 0,
+                    "column-store variable-size RLE encoded values": 0,
+                    "column-store variable-size deleted values": 0,
+                    "column-store variable-size leaf pages": 0,
+                    "fixed-record size": 0,
+                    "maximum internal page size": 4096,
+                    "maximum leaf page key size": 2867,
+                    "maximum leaf page size": 32768,
+                    "maximum leaf page value size": 67108864,
+                    "maximum tree depth": 3,
+                    "number of key/value pairs": 0,
+                    "overflow pages": 0,
+                    "row-store empty values": 0,
+                    "row-store internal pages": 0,
+                    "row-store leaf pages": 0
+                },
+                "cache": {
+                    "bytes currently in the cache": 5704,
+                    "bytes dirty in the cache cumulative": 899,
+                    "bytes read into cache": 0,
+                    "bytes written from cache": 4287,
+                    "checkpoint blocked page eviction": 0,
+                    "checkpoint of history store file blocked non-history store page eviction": 0,
+                    "data source pages selected for eviction unable to be evicted": 0,
+                    "eviction gave up due to detecting an out of order on disk value behind the last update on the chain": 0,
+                    "eviction gave up due to detecting an out of order tombstone ahead of the selected on disk update": 0,
+                    "eviction gave up due to detecting an out of order tombstone ahead of the selected on disk update after validating the update chain": 0,
+                    "eviction gave up due to detecting out of order timestamps on the update chain after the selected on disk update": 0,
+                    "eviction gave up due to needing to remove a record from the history store but checkpoint is running": 0,
+                    "eviction walk passes of a file": 0,
+                    "eviction walk target pages histogram - 0-9": 0,
+                    "eviction walk target pages histogram - 10-31": 0,
+                    "eviction walk target pages histogram - 128 and higher": 0,
+                    "eviction walk target pages histogram - 32-63": 0,
+                    "eviction walk target pages histogram - 64-128": 0,
+                    "eviction walk target pages reduced due to history store cache pressure": 0,
+                    "eviction walks abandoned": 0,
+                    "eviction walks gave up because they restarted their walk twice": 0,
+                    "eviction walks gave up because they saw too many pages and found no candidates": 0,
+                    "eviction walks gave up because they saw too many pages and found too few candidates": 0,
+                    "eviction walks reached end of tree": 0,
+                    "eviction walks restarted": 0,
+                    "eviction walks started from root of tree": 0,
+                    "eviction walks started from saved location in tree": 0,
+                    "hazard pointer blocked page eviction": 0,
+                    "history store table insert calls": 0,
+                    "history store table insert calls that returned restart": 0,
+                    "history store table out-of-order resolved updates that lose their durable timestamp": 0,
+                    "history store table out-of-order updates that were fixed up by reinserting with the fixed timestamp": 0,
+                    "history store table reads": 0,
+                    "history store table reads missed": 0,
+                    "history store table reads requiring squashed modifies": 0,
+                    "history store table truncation by rollback to stable to remove an unstable update": 0,
+                    "history store table truncation by rollback to stable to remove an update": 0,
+                    "history store table truncation to remove an update": 0,
+                    "history store table truncation to remove range of updates due to key being removed from the data page during reconciliation": 0,
+                    "history store table truncation to remove range of updates due to out-of-order timestamp update on data page": 0,
+                    "history store table writes requiring squashed modifies": 0,
+                    "in-memory page passed criteria to be split": 0,
+                    "in-memory page splits": 0,
+                    "internal pages evicted": 0,
+                    "internal pages split during eviction": 0,
+                    "leaf pages split during eviction": 0,
+                    "modified pages evicted": 0,
+                    "overflow pages read into cache": 0,
+                    "page split during eviction deepened the tree": 0,
+                    "page written requiring history store records": 0,
+                    "pages read into cache": 0,
+                    "pages read into cache after truncate": 1,
+                    "pages read into cache after truncate in prepare state": 0,
+                    "pages requested from the cache": 2,
+                    "pages seen by eviction walk": 0,
+                    "pages written from cache": 2,
+                    "pages written requiring in-memory restoration": 0,
+                    "the number of times full update inserted to history store": 0,
+                    "the number of times reverse modify inserted to history store": 0,
+                    "tracked dirty bytes in the cache": 0,
+                    "unmodified pages evicted": 0
+                },
+                "cache_walk": {
+                    "Average difference between current eviction generation when the page was last considered": 0,
+                    "Average on-disk page image size seen": 0,
+                    "Average time in cache for pages that have been visited by the eviction server": 0,
+                    "Average time in cache for pages that have not been visited by the eviction server": 0,
+                    "Clean pages currently in cache": 0,
+                    "Current eviction generation": 0,
+                    "Dirty pages currently in cache": 0,
+                    "Entries in the root page": 0,
+                    "Internal pages currently in cache": 0,
+                    "Leaf pages currently in cache": 0,
+                    "Maximum difference between current eviction generation when the page was last considered": 0,
+                    "Maximum page size seen": 0,
+                    "Minimum on-disk page image size seen": 0,
+                    "Number of pages never visited by eviction server": 0,
+                    "On-disk page image sizes smaller than a single allocation unit": 0,
+                    "Pages created in memory and never written": 0,
+                    "Pages currently queued for eviction": 0,
+                    "Pages that could not be queued for eviction": 0,
+                    "Refs skipped during cache traversal": 0,
+                    "Size of the root page": 0,
+                    "Total number of pages currently in cache": 0
+                },
+                "checkpoint-cleanup": {
+                    "pages added for eviction": 0,
+                    "pages removed": 0,
+                    "pages skipped during tree walk": 0,
+                    "pages visited": 1
+                },
+                "compression": {
+                    "compressed page maximum internal page size prior to compression": 4096,
+                    "compressed page maximum leaf page size prior to compression ": 131072,
+                    "compressed pages read": 0,
+                    "compressed pages written": 1,
+                    "number of blocks with compress ratio greater than 64": 0,
+                    "number of blocks with compress ratio smaller than 16": 0,
+                    "number of blocks with compress ratio smaller than 2": 0,
+                    "number of blocks with compress ratio smaller than 32": 0,
+                    "number of blocks with compress ratio smaller than 4": 0,
+                    "number of blocks with compress ratio smaller than 64": 0,
+                    "number of blocks with compress ratio smaller than 8": 0,
+                    "page written failed to compress": 0,
+                    "page written was too small to compress": 1
+                },
+                "cursor": {
+                    "Total number of entries skipped by cursor next calls": 0,
+                    "Total number of entries skipped by cursor prev calls": 0,
+                    "Total number of entries skipped to position the history store cursor": 0,
+                    "Total number of times a search near has exited due to prefix config": 0,
+                    "bulk loaded cursor insert calls": 0,
+                    "cache cursors reuse count": 0,
+                    "close calls that result in cache": 1,
+                    "create calls": 2,
+                    "cursor next calls that skip due to a globally visible history store tombstone": 0,
+                    "cursor next calls that skip greater than or equal to 100 entries": 0,
+                    "cursor next calls that skip less than 100 entries": 1,
+                    "cursor prev calls that skip due to a globally visible history store tombstone": 0,
+                    "cursor prev calls that skip greater than or equal to 100 entries": 0,
+                    "cursor prev calls that skip less than 100 entries": 1,
+                    "insert calls": 1,
+                    "insert key and value bytes": 4191,
+                    "modify": 0,
+                    "modify key and value bytes affected": 0,
+                    "modify value bytes modified": 0,
+                    "next calls": 1,
+                    "open cursor count": 0,
+                    "operation restarted": 0,
+                    "prev calls": 1,
+                    "remove calls": 0,
+                    "remove key bytes removed": 0,
+                    "reserve calls": 0,
+                    "reset calls": 5,
+                    "search calls": 0,
+                    "search history store calls": 0,
+                    "search near calls": 0,
+                    "truncate calls": 0,
+                    "update calls": 0,
+                    "update key and value bytes": 0,
+                    "update value size change": 0
+                },
+                "reconciliation": {
+                    "approximate byte size of timestamps in pages written": 0,
+                    "approximate byte size of transaction IDs in pages written": 0,
+                    "dictionary matches": 0,
+                    "fast-path pages deleted": 0,
+                    "internal page key bytes discarded using suffix compression": 0,
+                    "internal page multi-block writes": 0,
+                    "leaf page key bytes discarded using prefix compression": 0,
+                    "leaf page multi-block writes": 0,
+                    "leaf-page overflow keys": 0,
+                    "maximum blocks required for a page": 1,
+                    "overflow values written": 0,
+                    "page checksum matches": 0,
+                    "page reconciliation calls": 2,
+                    "page reconciliation calls for eviction": 0,
+                    "pages deleted": 0,
+                    "pages written including an aggregated newest start durable timestamp ": 0,
+                    "pages written including an aggregated newest stop durable timestamp ": 0,
+                    "pages written including an aggregated newest stop timestamp ": 0,
+                    "pages written including an aggregated newest stop transaction ID": 0,
+                    "pages written including an aggregated newest transaction ID ": 0,
+                    "pages written including an aggregated oldest start timestamp ": 0,
+                    "pages written including an aggregated prepare": 0,
+                    "pages written including at least one prepare": 0,
+                    "pages written including at least one start durable timestamp": 0,
+                    "pages written including at least one start timestamp": 0,
+                    "pages written including at least one start transaction ID": 0,
+                    "pages written including at least one stop durable timestamp": 0,
+                    "pages written including at least one stop timestamp": 0,
+                    "pages written including at least one stop transaction ID": 0,
+                    "records written including a prepare": 0,
+                    "records written including a start durable timestamp": 0,
+                    "records written including a start timestamp": 0,
+                    "records written including a start transaction ID": 0,
+                    "records written including a stop durable timestamp": 0,
+                    "records written including a stop timestamp": 0,
+                    "records written including a stop transaction ID": 0
+                },
+                "session": {
+                    "object compaction": 0,
+                    "tiered operations dequeued and processed": 0,
+                    "tiered operations scheduled": 0,
+                    "tiered storage local retention time (secs)": 0
+                },
+                "transaction": {
+                    "checkpoint has acquired a snapshot for its transaction": 0,
+                    "race to read prepared update retry": 0,
+                    "rollback to stable history store records with stop timestamps older than newer records": 0,
+                    "rollback to stable inconsistent checkpoint": 0,
+                    "rollback to stable keys removed": 0,
+                    "rollback to stable keys restored": 0,
+                    "rollback to stable restored tombstones from history store": 0,
+                    "rollback to stable restored updates from history store": 0,
+                    "rollback to stable skipping delete rle": 0,
+                    "rollback to stable skipping stable rle": 0,
+                    "rollback to stable sweeping history store keys": 0,
+                    "rollback to stable updates removed from history store": 0,
+                    "transaction checkpoints due to obsolete pages": 0,
+                    "update conflicts": 0
+                }
+            },
+            "sharded": false,
+            "size": 0.0039958953857421875,
+            "count": 1,
+            "numOrphanDocs": 0,
+            "storageSize": 0.01953125,
+            "totalIndexSize": 0.01953125,
+            "totalSize": 0.0390625,
+            "indexSizes": {
+                "_id_": 0.01953125
+            },
+            "avgObjSize": 4190,
+            "maxSize": 10,
+            "ns": "local.startup_log",
+            "nindexes": 1,
+            "scaleFactor": 1048576
+        },
+        "section": "data_info",
+        "subsection": "collection_stats_(mb)",
+        "ts": {
+            "start": {
+                "$date": 1692958193184
+            },
+            "end": {
+                "$date": 1692958193379
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).getCollection(col).getIndexes();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": [
+            {
+                "v": 2,
+                "key": {
+                    "_id": 1
+                },
+                "name": "_id_"
+            }
+        ],
+        "section": "data_info",
+        "subsection": "indexes",
+        "ts": {
+            "start": {
+                "$date": 1692958193379
+            },
+            "end": {
+                "$date": 1692958193471
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {
+            "db": "local",
+            "collection": "startup_log"
+        }
+    },
+    {
+        "command": "function(){\n\t\t\ttry {\n                                var res = db.getSiblingDB(mydb.name).runCommand( {\n                                  aggregate: col,\n                                  pipeline: [\n                                    {$indexStats: {}},\n                                    {$group: {_id: \"$key\", stats: {$push: {accesses: \"$accesses.ops\", host: \"$host\", since: \"$accesses.since\"}}}},\n                                    {$project: {key: \"$_id\", stats: 1, _id: 0}}\n                                  ],\n                                  cursor: {}\n                                });\n\t\t\t\terr=null;\n\t\t\t}catch(err) {\n\t\t\t\treturn \"Error running index stats on Database \" + mydb.name + \" Collection \" + col + \" Error: \" + err;\n\t\t\t}\n\n                                //It is assumed that there always will be a single batch as collections\n                                //are limited to 64 indexes and usage from all shards is grouped\n                                //into a single document\n\t\t\ttry {\n                                if (res.hasOwnProperty('cursor') && res.cursor.hasOwnProperty('firstBatch')) {\n                                  res.cursor.firstBatch.forEach(\n                                    function(d){\n                                      d.stats.forEach(\n                                        function(d){\n                                          d.since = d.since.toUTCString();\n                                        })\n                                    });\n                                } \n\t\t\t  err=null;\n\t\t\t} catch(err) {\n\t\t\t\treturn \"Error running index stats on Database \" + mydb.name + \" Collection \" + col + \" res processing Error: \" + err;\n\t\t\t}\n\n                                return res;\n\t\t}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "cursor": {
+                "firstBatch": [
+                    {
+                        "stats": [
+                            {
+                                "accesses": {
+                                    "$numberLong": "0"
+                                },
+                                "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net:27017",
+                                "since": "Fri, 25 Aug 2023 09:38:49 GMT"
+                            }
+                        ],
+                        "key": {
+                            "_id": 1
+                        }
+                    }
+                ],
+                "id": {
+                    "$numberLong": "0"
+                },
+                "ns": "local.startup_log"
+            },
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            }
+        },
+        "section": "data_info",
+        "subsection": "index_stats",
+        "ts": {
+            "start": {
+                "$date": 1692958193471
+            },
+            "end": {
+                "$date": 1692958193543
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).getCollection(col).stats(1024*1024);}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "ok": 1,
+            "capped": true,
+            "max": 0,
+            "wiredTiger": {
+                "metadata": {
+                    "formatVersion": 1,
+                    "oplogKeyExtractionVersion": 1
+                },
+                "creationString": "access_pattern_hint=none,allocation_size=4KB,app_metadata=(formatVersion=1,oplogKeyExtractionVersion=1),assert=(commit_timestamp=none,durable_timestamp=none,read_timestamp=none,write_timestamp=off),block_allocation=best,block_compressor=snappy,cache_resident=false,checksum=on,colgroups=,collator=,columns=,dictionary=0,encryption=(keyid=,name=),exclusive=false,extractor=,format=btree,huffman_key=,huffman_value=,ignore_in_memory_cache_size=false,immutable=false,import=(compare_timestamp=oldest_timestamp,enabled=false,file_metadata=,metadata_file=,repair=false),internal_item_max=0,internal_key_max=0,internal_key_truncate=true,internal_page_max=4KB,key_format=q,key_gap=10,leaf_item_max=0,leaf_key_max=0,leaf_page_max=32KB,leaf_value_max=64MB,log=(enabled=true),lsm=(auto_throttle=true,bloom=true,bloom_bit_count=16,bloom_config=,bloom_hash_count=8,bloom_oldest=false,chunk_count_limit=0,chunk_max=5GB,chunk_size=10MB,merge_custom=(prefix=,start_generation=0,suffix=),merge_max=15,merge_min=0),memory_page_image_max=0,memory_page_max=10m,os_cache_dirty_max=0,os_cache_max=0,prefix_compression=false,prefix_compression_min=4,readonly=false,source=,split_deepen_min_child=0,split_deepen_per_child=0,split_pct=90,tiered_object=false,tiered_storage=(auth_token=,bucket=,bucket_prefix=,cache_directory=,local_retention=300,name=,object_target_size=0),type=file,value_format=u,verbose=[],write_timestamp_usage=none",
+                "type": "file",
+                "uri": "statistics:table:collection-22--4235276012238614669",
+                "LSM": {
+                    "bloom filter false positives": 0,
+                    "bloom filter hits": 0,
+                    "bloom filter misses": 0,
+                    "bloom filter pages evicted from cache": 0,
+                    "bloom filter pages read into cache": 0,
+                    "bloom filters in the LSM tree": 0,
+                    "chunks in the LSM tree": 0,
+                    "highest merge generation in the LSM tree": 0,
+                    "queries that could have benefited from a Bloom filter that did not exist": 0,
+                    "sleep for LSM checkpoint throttle": 0,
+                    "sleep for LSM merge throttle": 0,
+                    "total size of bloom filters": 0
+                },
+                "autocommit": {
+                    "retries for readonly operations": 0,
+                    "retries for update operations": 0
+                },
+                "block-manager": {
+                    "allocations requiring file extension": 25,
+                    "blocks allocated": 124,
+                    "blocks freed": 30,
+                    "checkpoint size": 16384,
+                    "file allocation unit size": 4096,
+                    "file bytes available for reuse": 24576,
+                    "file magic number": 120897,
+                    "file major version number": 1,
+                    "file size in bytes": 57344,
+                    "minor version number": 0
+                },
+                "btree": {
+                    "btree checkpoint generation": 33,
+                    "btree clean tree checkpoint expiration time": 0,
+                    "btree compact pages reviewed": 0,
+                    "btree compact pages rewritten": 0,
+                    "btree compact pages skipped": 0,
+                    "btree skipped by compaction as process would not reduce size": 0,
+                    "column-store fixed-size leaf pages": 0,
+                    "column-store fixed-size time windows": 0,
+                    "column-store internal pages": 0,
+                    "column-store variable-size RLE encoded values": 0,
+                    "column-store variable-size deleted values": 0,
+                    "column-store variable-size leaf pages": 0,
+                    "fixed-record size": 0,
+                    "maximum internal page size": 4096,
+                    "maximum leaf page key size": 2867,
+                    "maximum leaf page size": 32768,
+                    "maximum leaf page value size": 67108864,
+                    "maximum tree depth": 3,
+                    "number of key/value pairs": 0,
+                    "overflow pages": 0,
+                    "row-store empty values": 0,
+                    "row-store internal pages": 0,
+                    "row-store leaf pages": 0
+                },
+                "cache": {
+                    "bytes currently in the cache": 110247,
+                    "bytes dirty in the cache cumulative": 1869702,
+                    "bytes read into cache": 0,
+                    "bytes written from cache": 1257204,
+                    "checkpoint blocked page eviction": 0,
+                    "checkpoint of history store file blocked non-history store page eviction": 0,
+                    "data source pages selected for eviction unable to be evicted": 0,
+                    "eviction gave up due to detecting an out of order on disk value behind the last update on the chain": 0,
+                    "eviction gave up due to detecting an out of order tombstone ahead of the selected on disk update": 0,
+                    "eviction gave up due to detecting an out of order tombstone ahead of the selected on disk update after validating the update chain": 0,
+                    "eviction gave up due to detecting out of order timestamps on the update chain after the selected on disk update": 0,
+                    "eviction gave up due to needing to remove a record from the history store but checkpoint is running": 0,
+                    "eviction walk passes of a file": 0,
+                    "eviction walk target pages histogram - 0-9": 0,
+                    "eviction walk target pages histogram - 10-31": 0,
+                    "eviction walk target pages histogram - 128 and higher": 0,
+                    "eviction walk target pages histogram - 32-63": 0,
+                    "eviction walk target pages histogram - 64-128": 0,
+                    "eviction walk target pages reduced due to history store cache pressure": 0,
+                    "eviction walks abandoned": 0,
+                    "eviction walks gave up because they restarted their walk twice": 0,
+                    "eviction walks gave up because they saw too many pages and found no candidates": 0,
+                    "eviction walks gave up because they saw too many pages and found too few candidates": 0,
+                    "eviction walks reached end of tree": 0,
+                    "eviction walks restarted": 0,
+                    "eviction walks started from root of tree": 0,
+                    "eviction walks started from saved location in tree": 0,
+                    "hazard pointer blocked page eviction": 0,
+                    "history store table insert calls": 0,
+                    "history store table insert calls that returned restart": 0,
+                    "history store table out-of-order resolved updates that lose their durable timestamp": 0,
+                    "history store table out-of-order updates that were fixed up by reinserting with the fixed timestamp": 0,
+                    "history store table reads": 0,
+                    "history store table reads missed": 0,
+                    "history store table reads requiring squashed modifies": 0,
+                    "history store table truncation by rollback to stable to remove an unstable update": 0,
+                    "history store table truncation by rollback to stable to remove an update": 0,
+                    "history store table truncation to remove an update": 0,
+                    "history store table truncation to remove range of updates due to key being removed from the data page during reconciliation": 0,
+                    "history store table truncation to remove range of updates due to out-of-order timestamp update on data page": 0,
+                    "history store table writes requiring squashed modifies": 0,
+                    "in-memory page passed criteria to be split": 0,
+                    "in-memory page splits": 0,
+                    "internal pages evicted": 0,
+                    "internal pages split during eviction": 0,
+                    "leaf pages split during eviction": 0,
+                    "modified pages evicted": 0,
+                    "overflow pages read into cache": 0,
+                    "page split during eviction deepened the tree": 0,
+                    "page written requiring history store records": 0,
+                    "pages read into cache": 0,
+                    "pages read into cache after truncate": 1,
+                    "pages read into cache after truncate in prepare state": 0,
+                    "pages requested from the cache": 4466,
+                    "pages seen by eviction walk": 0,
+                    "pages written from cache": 62,
+                    "pages written requiring in-memory restoration": 0,
+                    "the number of times full update inserted to history store": 0,
+                    "the number of times reverse modify inserted to history store": 0,
+                    "tracked dirty bytes in the cache": 109753,
+                    "unmodified pages evicted": 0
+                },
+                "cache_walk": {
+                    "Average difference between current eviction generation when the page was last considered": 0,
+                    "Average on-disk page image size seen": 0,
+                    "Average time in cache for pages that have been visited by the eviction server": 0,
+                    "Average time in cache for pages that have not been visited by the eviction server": 0,
+                    "Clean pages currently in cache": 0,
+                    "Current eviction generation": 0,
+                    "Dirty pages currently in cache": 0,
+                    "Entries in the root page": 0,
+                    "Internal pages currently in cache": 0,
+                    "Leaf pages currently in cache": 0,
+                    "Maximum difference between current eviction generation when the page was last considered": 0,
+                    "Maximum page size seen": 0,
+                    "Minimum on-disk page image size seen": 0,
+                    "Number of pages never visited by eviction server": 0,
+                    "On-disk page image sizes smaller than a single allocation unit": 0,
+                    "Pages created in memory and never written": 0,
+                    "Pages currently queued for eviction": 0,
+                    "Pages that could not be queued for eviction": 0,
+                    "Refs skipped during cache traversal": 0,
+                    "Size of the root page": 0,
+                    "Total number of pages currently in cache": 0
+                },
+                "checkpoint-cleanup": {
+                    "pages added for eviction": 0,
+                    "pages removed": 0,
+                    "pages skipped during tree walk": 0,
+                    "pages visited": 31
+                },
+                "compression": {
+                    "compressed page maximum internal page size prior to compression": 4096,
+                    "compressed page maximum leaf page size prior to compression ": 131072,
+                    "compressed pages read": 0,
+                    "compressed pages written": 30,
+                    "number of blocks with compress ratio greater than 64": 0,
+                    "number of blocks with compress ratio smaller than 16": 0,
+                    "number of blocks with compress ratio smaller than 2": 0,
+                    "number of blocks with compress ratio smaller than 32": 0,
+                    "number of blocks with compress ratio smaller than 4": 0,
+                    "number of blocks with compress ratio smaller than 64": 0,
+                    "number of blocks with compress ratio smaller than 8": 0,
+                    "page written failed to compress": 0,
+                    "page written was too small to compress": 32
+                },
+                "cursor": {
+                    "Total number of entries skipped by cursor next calls": 8,
+                    "Total number of entries skipped by cursor prev calls": 0,
+                    "Total number of entries skipped to position the history store cursor": 0,
+                    "Total number of times a search near has exited due to prefix config": 0,
+                    "bulk loaded cursor insert calls": 0,
+                    "cache cursors reuse count": 1771,
+                    "close calls that result in cache": 1773,
+                    "create calls": 4,
+                    "cursor next calls that skip due to a globally visible history store tombstone": 0,
+                    "cursor next calls that skip greater than or equal to 100 entries": 0,
+                    "cursor next calls that skip less than 100 entries": 4494,
+                    "cursor prev calls that skip due to a globally visible history store tombstone": 0,
+                    "cursor prev calls that skip greater than or equal to 100 entries": 0,
+                    "cursor prev calls that skip less than 100 entries": 263,
+                    "insert calls": 336,
+                    "insert key and value bytes": 71974,
+                    "modify": 0,
+                    "modify key and value bytes affected": 0,
+                    "modify value bytes modified": 0,
+                    "next calls": 4494,
+                    "open cursor count": 2,
+                    "operation restarted": 0,
+                    "prev calls": 263,
+                    "remove calls": 0,
+                    "remove key bytes removed": 0,
+                    "reserve calls": 0,
+                    "reset calls": 6217,
+                    "search calls": 3830,
+                    "search history store calls": 0,
+                    "search near calls": 2,
+                    "truncate calls": 0,
+                    "update calls": 0,
+                    "update key and value bytes": 0,
+                    "update value size change": 0
+                },
+                "reconciliation": {
+                    "approximate byte size of timestamps in pages written": 0,
+                    "approximate byte size of transaction IDs in pages written": 0,
+                    "dictionary matches": 0,
+                    "fast-path pages deleted": 0,
+                    "internal page key bytes discarded using suffix compression": 10,
+                    "internal page multi-block writes": 0,
+                    "leaf page key bytes discarded using prefix compression": 0,
+                    "leaf page multi-block writes": 0,
+                    "leaf-page overflow keys": 0,
+                    "maximum blocks required for a page": 1,
+                    "overflow values written": 0,
+                    "page checksum matches": 0,
+                    "page reconciliation calls": 62,
+                    "page reconciliation calls for eviction": 0,
+                    "pages deleted": 0,
+                    "pages written including an aggregated newest start durable timestamp ": 8,
+                    "pages written including an aggregated newest stop durable timestamp ": 2,
+                    "pages written including an aggregated newest stop timestamp ": 0,
+                    "pages written including an aggregated newest stop transaction ID": 0,
+                    "pages written including an aggregated newest transaction ID ": 8,
+                    "pages written including an aggregated oldest start timestamp ": 2,
+                    "pages written including an aggregated prepare": 0,
+                    "pages written including at least one prepare": 0,
+                    "pages written including at least one start durable timestamp": 0,
+                    "pages written including at least one start timestamp": 0,
+                    "pages written including at least one start transaction ID": 0,
+                    "pages written including at least one stop durable timestamp": 0,
+                    "pages written including at least one stop timestamp": 0,
+                    "pages written including at least one stop transaction ID": 0,
+                    "records written including a prepare": 0,
+                    "records written including a start durable timestamp": 0,
+                    "records written including a start timestamp": 0,
+                    "records written including a start transaction ID": 0,
+                    "records written including a stop durable timestamp": 0,
+                    "records written including a stop timestamp": 0,
+                    "records written including a stop transaction ID": 0
+                },
+                "session": {
+                    "object compaction": 0,
+                    "tiered operations dequeued and processed": 0,
+                    "tiered operations scheduled": 0,
+                    "tiered storage local retention time (secs)": 0
+                },
+                "transaction": {
+                    "checkpoint has acquired a snapshot for its transaction": 0,
+                    "race to read prepared update retry": 0,
+                    "rollback to stable history store records with stop timestamps older than newer records": 0,
+                    "rollback to stable inconsistent checkpoint": 0,
+                    "rollback to stable keys removed": 0,
+                    "rollback to stable keys restored": 0,
+                    "rollback to stable restored tombstones from history store": 0,
+                    "rollback to stable restored updates from history store": 0,
+                    "rollback to stable skipping delete rle": 0,
+                    "rollback to stable skipping stable rle": 0,
+                    "rollback to stable sweeping history store keys": 0,
+                    "rollback to stable updates removed from history store": 0,
+                    "transaction checkpoints due to obsolete pages": 0,
+                    "update conflicts": 0
+                }
+            },
+            "sharded": false,
+            "size": 0.06575584411621094,
+            "count": 336,
+            "numOrphanDocs": 0,
+            "storageSize": 0.0546875,
+            "totalIndexSize": 0,
+            "totalSize": 0.0546875,
+            "indexSizes": {},
+            "avgObjSize": 205,
+            "maxSize": 990,
+            "ns": "local.oplog.rs",
+            "nindexes": 0,
+            "scaleFactor": 1048576
+        },
+        "section": "data_info",
+        "subsection": "collection_stats_(mb)",
+        "ts": {
+            "start": {
+                "$date": 1692958193543
+            },
+            "end": {
+                "$date": 1692958193726
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    },
+    {
+        "command": "function(){return db.getSiblingDB(mydb.name).getCollection(col).getIndexes();}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": [],
+        "section": "data_info",
+        "subsection": "indexes",
+        "ts": {
+            "start": {
+                "$date": 1692958193726
+            },
+            "end": {
+                "$date": 1692958193802
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {
+            "db": "local",
+            "collection": "oplog.rs"
+        }
+    },
+    {
+        "command": "function(){\n\t\t\ttry {\n                                var res = db.getSiblingDB(mydb.name).runCommand( {\n                                  aggregate: col,\n                                  pipeline: [\n                                    {$indexStats: {}},\n                                    {$group: {_id: \"$key\", stats: {$push: {accesses: \"$accesses.ops\", host: \"$host\", since: \"$accesses.since\"}}}},\n                                    {$project: {key: \"$_id\", stats: 1, _id: 0}}\n                                  ],\n                                  cursor: {}\n                                });\n\t\t\t\terr=null;\n\t\t\t}catch(err) {\n\t\t\t\treturn \"Error running index stats on Database \" + mydb.name + \" Collection \" + col + \" Error: \" + err;\n\t\t\t}\n\n                                //It is assumed that there always will be a single batch as collections\n                                //are limited to 64 indexes and usage from all shards is grouped\n                                //into a single document\n\t\t\ttry {\n                                if (res.hasOwnProperty('cursor') && res.cursor.hasOwnProperty('firstBatch')) {\n                                  res.cursor.firstBatch.forEach(\n                                    function(d){\n                                      d.stats.forEach(\n                                        function(d){\n                                          d.since = d.since.toUTCString();\n                                        })\n                                    });\n                                } \n\t\t\t  err=null;\n\t\t\t} catch(err) {\n\t\t\t\treturn \"Error running index stats on Database \" + mydb.name + \" Collection \" + col + \" res processing Error: \" + err;\n\t\t\t}\n\n                                return res;\n\t\t}",
+        "error": null,
+        "host": "atlas-b5vr7t-shard-00-01.mns8wfq.mongodb.net",
+        "ref": null,
+        "tag": {
+            "$oid": "64e87deb79541111ff51e4c5"
+        },
+        "output": {
+            "cursor": {
+                "firstBatch": [],
+                "id": {
+                    "$numberLong": "0"
+                },
+                "ns": "local.oplog.rs"
+            },
+            "ok": 1,
+            "$clusterTime": {
+                "clusterTime": {
+                    "$timestamp": {
+                        "t": 1692958184,
+                        "i": 1
+                    }
+                },
+                "signature": {
+                    "hash": "sMSuWAERpu8cnpbe2K6YLOnG9hU=",
+                    "keyId": {
+                        "$numberLong": "7271192126740758533"
+                    }
+                }
+            },
+            "operationTime": {
+                "$timestamp": {
+                    "t": 1692958184,
+                    "i": 1
+                }
+            }
+        },
+        "section": "data_info",
+        "subsection": "index_stats",
+        "ts": {
+            "start": {
+                "$date": 1692958193802
+            },
+            "end": {
+                "$date": 1692958193875
+            }
+        },
+        "version": "1.0.0",
+        "commandParameters": {}
+    }
+]


### PR DESCRIPTION
This PR introduces a new script which replicates the functionality of the existing getMongoData.js legacy mongo shell script. The new script provides the same functionality and output but is written using a modern mongosh shell program.

Changes introduced:

1. Addition of new script 'mongoWellnessChecker.js' that performs the same functionality as 'getMongoData.js'
2. Updated README file for the new 'mongoWellnessChecker.js'  script.
3. Sample Output from the new script.
4. 'getMongoData.js' is preserved for history and backward compatibility.

To verify the correctness of the new script, we have run a series of tests that cover all functions of the legacy script. 

The rationale for creating a duplicate instead of refactoring the original script is to ensure a smooth transition and avoid potential service disruptions.