### PR TITLE
Fix permission errors when running getMongoData.js against Atlas, allow to ignore errors

### DIFF
--- a/getMongoData/README.md
+++ b/getMongoData/README.md
@@ -32,6 +32,11 @@ execution:
 
     mongo --eval "var _printJSON=false;" getMongoData.js > getMongoData-output.log
 
+To run the tool against a database that imitates (but doesn't fully implement) the MongoDB API, it can
+help to ignore some errors with the following `eval` option:
+
+    mongo --eval "var _abort_on_error=false;" getMongoData.js > getMongoData-output.log
+
 To have a `mongos` for a sharded cluster output full details of chunk
 distribution across shards, include `var _printChunkDetails=true` in the
 `--eval` option:

--- a/getMongoData/getMongoData.js
+++ b/getMongoData/getMongoData.js
@@ -233,7 +233,7 @@ function printInfo(message, command, section, printCapture, commandParameters) {
             print("Error running '" + command + "':");
             print(err);
         } else {
-            throw("Error running '" + command + "': " + err);
+            throw new Error("Error running '" + command + "': " + err);
         }
     }
     endTime = new Date();

--- a/getMongoData/getMongoData.js
+++ b/getMongoData/getMongoData.js
@@ -229,7 +229,7 @@ function printInfo(message, command, section, printCapture, commandParameters) {
         }
         err = null
     } catch(err) {
-        if (! _printJSON) {
+        if (! _printJSON || ! _abort_on_error) {
             print("Error running '" + command + "':");
             print(err);
         } else {
@@ -580,6 +580,7 @@ function printShardOrReplicaSetInfo() {
 }
 
 if (typeof _printJSON === "undefined") var _printJSON = true;
+if (typeof _abort_on_error === "undefined") var _abort_on_error = false;
 if (typeof _printChunkDetails === "undefined") var _printChunkDetails = false;
 if (typeof _ref === "undefined") var _ref = null;
 

--- a/getMongoData/getMongoData.js
+++ b/getMongoData/getMongoData.js
@@ -503,6 +503,8 @@ function printDataInfo(isMongoS) {
                     }
                     printInfo('Indexes',
                               function(){return db.getSiblingDB(mydb.name).getCollection(col).getIndexes()}, section, false, {"db": mydb.name, "collection": col});
+                    if (mydb.name == 'local')
+                        return;
                     printInfo('Index Stats',
                               function(){
                                 var res = db.getSiblingDB(mydb.name).runCommand( {


### PR DESCRIPTION
- Running against Atlas creates permission errors with the `local` db
- The error message is lost since the throw uses a string and the catch tries to access an Error objects
- Imitators like DocumentDB fail some of the initial commands but deliver useful index and sizing results, allow to ignore those first errors.