### PR TITLE
SERVER-98273 Create remediation for measurements are not sorted in increasing order for v2 buckets, or are sorted for v3 buckets

### DIFF
--- a/bucket-version-mismatch/README.md
+++ b/bucket-version-mismatch/README.md
@@ -72,6 +72,14 @@ coll.validate();
 }
 }
 ```
+with the logs:
+```
+..."c":"STORAGE",  "id":6698300, "ctx":"conn9","msg":"Document is not compliant with time-series specifications","attr":{"namespace":"[...]","recordId":[...],"reason":{"code":2,"codeName":"BadValue","errmsg":"Time-series bucket 't' field is not in ascending order"}}...
+```
+or 
+```
+..."c":"STORAGE",  "id":6698300, "ctx":"conn9","msg":"Document is not compliant with time-series specifications","attr":{"namespace":"[...]","recordId":[...],"reason":{"code":2,"codeName":"BadValue","errmsg":"Time-series bucket is v3 but has its measurements in-order on time"}}...
+```
 # Remediation
 ## Rewrite Bucket Version in a Time Series Collections
 While the script is running, the performance of operations on the time-series collection may be impacted. The script does a scan of the whole collection and performs updates on impacted buckets, which may result in a large load if many buckets are affected.  

--- a/bucket-version-mismatch/README.md
+++ b/bucket-version-mismatch/README.md
@@ -1,0 +1,101 @@
+# Troubleshoot Bucket Version Mismatch in Time Series Collections
+For more context on this issue, see [SERVER-94471](https://jira.mongodb.org/browse/SERVER-94471).
+## Warning
+The scripts provided here are best run by those experienced with MongoDB, ideally with guidance from MongoDB Technical Support. They are provided without warranty or guarantee of any kind (see disclaimer below). If you do not have access to MongoDB Technical Support, consider reaching out to our community at [community.mongodb.com](community.mongodb.com) to ask questions.
+Some adaptation of these scripts may be required for your use-case.
+If you are using these scripts on your own, we strongly recommend:
+* reading all instructions before attempting any action, and ensuring you are prepared for all steps.
+* taking regular backups of the [dbpaths](https://docs.mongodb.com/manual/core/backups/#back-up-by-copying-underlying-data-files) of each node, and working off of backups as much as possible.
+* reviewing the scripts themselves to understand their behavior.
+* testing this process and all scripts on a copy of the environment it is to be run.
+* for sharded clusters, disabling the balancer.
+# Prerequisites 
+- This script should be run with a user that has [dbAdmin](https://www.mongodb.com/docs/v6.0/reference/built-in-roles/#mongodb-authrole-dbAdmin) permissions on the database(s) for the affected time-series collection(s).
+-  If running on Atlas:
+   - We have already reached out to impacted customers. If we have reached out, you can skip the [Determine if You're Impacted section](#Determine-if-You're-Impacted) and start taking the steps under the [Remediation section](#remediation).
+   - Additionally, we recommend using the [Atlas Admin](https://www.mongodb.com/docs/atlas/security-add-mongodb-users/#built-in-roles) role.
+# Determine if You're Impacted
+Please see [SERVER-94471](https://jira.mongodb.org/browse/SERVER-94471) for the affected versions. Users can determine if they have been impacted by running [`validate`](https://www.mongodb.com/docs/v7.0/reference/command/validate/) on their Time Series collections and checking the `validate.errors` field to determine if there are buckets with mismatched versions. 
+The validation command [can be very impactful](https://www.mongodb.com/docs/v7.0/reference/method/db.collection.validate/#performance). To minimize the performance impact of running validate, issue validate to a secondary and follow [these steps](https://www.mongodb.com/docs/v7.0/reference/method/db.collection.validate/#performance:~:text=Validation%20has%20exclusive,the%20hidden%20node). 
+Example `validate` run on a standalone/replica set:
+```
+// Call validate on a mongod process for replica sets. 
+coll.validate();
+// The warnings field detects mixed-schema buckets. 
+{
+"ns" : "db.system.buckets.coll",
+...
+"errors" : [
+    Detected one or more documents in this collection incompatible with time-series
+    specifications. For more info, see logs with log id 6698300.,
+    ...
+],
+...
+}
+```
+with the logs:
+```
+..."c":"STORAGE",  "id":6698300, "ctx":"conn9","msg":"Document is not compliant with time-series specifications","attr":{"namespace":"[...]","recordId":[...],"reason":{"code":2,"codeName":"BadValue","errmsg":"Time-series bucket 't' field is not in ascending order"}}...
+```
+or 
+```
+..."c":"STORAGE",  "id":6698300, "ctx":"conn9","msg":"Document is not compliant with time-series specifications","attr":{"namespace":"[...]","recordId":[...],"reason":{"code":2,"codeName":"BadValue","errmsg":"Time-series bucket is v3 but has its measurements in-order on time"}}...
+```
+Example `validate` run on a sharded cluster:
+```
+// Call validate on mongos for sharded clusters.
+coll.validate();
+// The warnings field detects mixed-schema buckets.
+// For sharded clusters, this output is an object with a result for every shard in 
+// the "raw" field.
+{
+	"ns" : "db.system.buckets.coll",
+	...
+"errors" : [
+    Detected one or more documents in this collection incompatible with time-series
+    specifications. For more info, see logs with log id 6698300.,
+    ...
+],
+...
+"raw" : {
+	"shard-0-name" : {
+		"ns" : "db.system.buckets.coll"
+		...
+"errors" : [
+    Detected one or more documents in this collection incompatible with time-series
+    specifications. For more info, see logs with log id 6698300.,
+    ...
+],
+...
+},
+"shard-1-name" : { ... }, ...
+}
+}
+```
+# Remediation
+## Rewrite Bucket Version in a Time Series Collections
+While the script is running, the performance of operations on the time-series collection may be impacted. The script does a scan of the whole collection and performs updates on impacted buckets, which may result in a large load if many buckets are affected.  
+At a high level, the script remediates performance by updating the bucket's version from v2 to v3 and vice versa if a v2 bucket has unsorted data, and if a  from the mixed-schema format to the older schema.  The rewrite is done by unpacking the measurements of the problematic mixed-schema buckets and inserting those measurements back into the collection.
+The full steps are as follows. For each bucket in the time series collection:
+- Detect if the bucket has bucket version mismatch.
+- Change the buckets with bucket version mismatch to the correct version.
+- Validate that there are no bucket version mismatches.
+**Warning**: This script directly modifies `<database>.system.buckets` collection —the underlying buckets of the Time Series collection—in order to remediate performance issues. Under normal circumstances, users should not modify this collection. 
+Please contact [MongoDB Support](https://support.mongodb.com/welcome) with any questions or concerns regarding running this script. 
+### Running the remediation script
+#### 1. Modify the script by populating `collName` with the name of your collection
+```
+// ------------------------------------------------------------------------------------
+// Populate collName with the time-series collection with mixed-schema buckets.
+// ------------------------------------------------------------------------------------
+const collName = "your_collection_name";
+```
+#### 2. Connect to your sharded cluster using [mongosh](https://www.mongodb.com/docs/mongodb-shell/):
+```
+mongosh --uri <URI>
+```
+#### 3. Load the script `rewrite_timeseries_bucket_version_mismatch.js`
+```
+load("rewrite_timeseries_bucket_version_mismatch.js")
+```
+#### 4. Repeat steps 1-3 for each time-series collection that was affected.

--- a/bucket-version-mismatch/README.md
+++ b/bucket-version-mismatch/README.md
@@ -83,7 +83,7 @@ or
 # Remediation
 ## Rewrite Bucket Version in a Time Series Collections
 While the script is running, the performance of operations on the time-series collection may be impacted. The script does a scan of the whole collection and performs updates on impacted buckets, which may result in a large load if many buckets are affected.  
-At a high level, the script remediates performance by updating the bucket's version from v2 to v3 and vice versa if a v2 bucket has unsorted data, and if a  from the mixed-schema format to the older schema.  The rewrite is done by unpacking the measurements of the problematic mixed-schema buckets and inserting those measurements back into the collection.
+At a high level, the script remediates errors during collection validation by updating the bucket's version from v2 to v3 and vice versa if a v2 bucket has unsorted data, and if a from the mixed-schema format to the older schema. The rewrite is done by unpacking the measurements of the problematic mixed-schema buckets and inserting those measurements back into the collection.
 The full steps are as follows. For each bucket in the time series collection:
 - Detect if the bucket has bucket version mismatch.
 - Change the buckets with bucket version mismatch to the correct version.

--- a/bucket-version-mismatch/README.md
+++ b/bucket-version-mismatch/README.md
@@ -35,11 +35,11 @@ coll.validate();
 ```
 with the logs:
 ```
-..."c":"STORAGE",  "id":6698300, "ctx":"conn9","msg":"Document is not compliant with time-series specifications","attr":{"namespace":"[...]","recordId":[...],"reason":{"code":2,"codeName":"BadValue","errmsg":"Time-series bucket 't' field is not in ascending order"}}...
+..."c":"STORAGE",  "id":6698300, "ctx":"conn9","msg":"Document is not compliant with time-series specifications","attr":{..."reason":{"code":2,"codeName":"BadValue","errmsg":"Time-series bucket [...] field is not in ascending order"}}...
 ```
 or 
 ```
-..."c":"STORAGE",  "id":6698300, "ctx":"conn9","msg":"Document is not compliant with time-series specifications","attr":{"namespace":"[...]","recordId":[...],"reason":{"code":2,"codeName":"BadValue","errmsg":"Time-series bucket is v3 but has its measurements in-order on time"}}...
+..."c":"STORAGE",  "id":6698300, "ctx":"conn9","msg":"Document is not compliant with time-series specifications","attr":{..."reason":{"code":2,"codeName":"BadValue","errmsg":"Time-series bucket is v3 but has its measurements in-order on time"}}...
 ```
 Example `validate` run on a sharded cluster:
 ```
@@ -74,11 +74,11 @@ coll.validate();
 ```
 with the logs:
 ```
-..."c":"STORAGE",  "id":6698300, "ctx":"conn9","msg":"Document is not compliant with time-series specifications","attr":{"namespace":"[...]","recordId":[...],"reason":{"code":2,"codeName":"BadValue","errmsg":"Time-series bucket 't' field is not in ascending order"}}...
+..."c":"STORAGE",  "id":6698300, "ctx":"conn9","msg":"Document is not compliant with time-series specifications","attr":{..."reason":{"code":2,"codeName":"BadValue","errmsg":"Time-series bucket [...] field is not in ascending order"}}...
 ```
 or 
 ```
-..."c":"STORAGE",  "id":6698300, "ctx":"conn9","msg":"Document is not compliant with time-series specifications","attr":{"namespace":"[...]","recordId":[...],"reason":{"code":2,"codeName":"BadValue","errmsg":"Time-series bucket is v3 but has its measurements in-order on time"}}...
+..."c":"STORAGE",  "id":6698300, "ctx":"conn9","msg":"Document is not compliant with time-series specifications","attr":{..."reason":{"code":2,"codeName":"BadValue","errmsg":"Time-series bucket is v3 but has its measurements in-order on time"}}...
 ```
 # Remediation
 ## Rewrite Bucket Version in a Time Series Collections

--- a/bucket-version-mismatch/rewrite_timeseries_bucket_version_mismatch.js
+++ b/bucket-version-mismatch/rewrite_timeseries_bucket_version_mismatch.js
@@ -67,7 +67,7 @@ function runFixBucketVersionMismatchProcedure(collName) {
   // Range through all the bucketDocs and change the control version of the
   // bucket from 2 -> 3 if the data is not sorted or from 3 -> 2 if the data is
   // sorted.
-  const bucketsColl = db.getCollection('system.buckets.' + collName);
+  const bucketsColl = db.getCollection('system.buckets.' + coll.getName());
   var cursor = bucketsColl.find({});
 
   while (cursor.hasNext()) {

--- a/bucket-version-mismatch/rewrite_timeseries_bucket_version_mismatch.js
+++ b/bucket-version-mismatch/rewrite_timeseries_bucket_version_mismatch.js
@@ -67,7 +67,7 @@ function runFixBucketVersionMismatchProcedure(collName) {
   // Range through all the bucketDocs and change the control version of the
   // bucket from 2 -> 3 if the data is not sorted or from 3 -> 2 if the data is
   // sorted.
-  const bucketsColl = db.getCollection('system.buckets.' + collName.getName());
+  const bucketsColl = db.getCollection('system.buckets.' + collName);
   var cursor = bucketsColl.find({});
 
   while (cursor.hasNext()) {

--- a/bucket-version-mismatch/rewrite_timeseries_bucket_version_mismatch.js
+++ b/bucket-version-mismatch/rewrite_timeseries_bucket_version_mismatch.js
@@ -1,0 +1,92 @@
+// ------------------------------------------------------------------------------------
+// Populate collName with the time-series collection that failed validation due
+// to v2/v3 timeseries buckets not in correct sorted/unsorted order
+// respectively.
+// ------------------------------------------------------------------------------------
+const collName = 'your_collection_name';
+
+let listCollectionsRes = db.runCommand({
+                             listCollections: 1.0,
+                             filter: {name: collName}
+                           }).cursor.firstBatch;
+if (listCollectionsRes.length == 0) {
+  print(
+      'Collection not found. Populate collName with the time-series collection that failed due to v2/v3 timeseries buckets not in correct sorted/unsorted order respectively.');
+  exit(1);
+}
+const coll = db.getCollection(collName);
+
+//
+// NON-MODIFIABLE CODE BELOW
+//
+// ---------------------------------------------------------------------------------------
+// The script will, for each bucket in the affected time-series collection:
+// 1) Detect if the bucket has bucket version mismatch.
+// 2) Change the buckets with bucket version mismatch to the correct version.
+// 3) Validate that there are no bucket version mismatches.
+// ----------------------------------------------------------------------------------------
+
+BucketVersion = {
+  kCompressedSorted: 2,
+  kCompressedUnsorted: 3
+};
+
+function bucketHasMismatchedBucketVersion(
+    bucketsColl, bucketId, bucketControlVersion) {
+  let measurements = bucketsColl
+                         .aggregate([
+                           {$match: {_id: bucketId}}, {
+                             $_unpackBucket: {
+                               timeField: 't',
+                             }
+                           }
+                         ])
+                         .toArray();
+  let prevTimestamp = new Date(-8640000000000000);
+  let detectedOutOfOrder = false;
+  for (let i = 0; i < measurements.length; i++) {
+    let currMeasurement = measurements[i]['t'];
+    let currTimestamp = new Date(currMeasurement);
+    if (currTimestamp < prevTimestamp) {
+      if (bucketControlVersion == BucketVersion.kCompressedSorted) {
+        return true;
+      } else if (bucketControlVersion == BucketVersion.kCompressedUnsorted) {
+        detectedOutOfOrder = true;
+      }
+    }
+    prevTimestamp = currTimestamp;
+  }
+  return !detectedOutOfOrder &&
+      (bucketControlVersion == BucketVersion.kCompressedUnsorted);
+}
+
+function runFixBucketVersionMismatchProcedure(collName) {
+  print(
+      'Checking if the bucket versions match their data in ' + collName +
+      ' ...\n');
+  // Range through all the bucketDocs and change the control version of the
+  // bucket from 2 -> 3 if the data is not sorted or from 3 -> 2 if the data is
+  // sorted.
+  const bucketsColl = db.getCollection('system.buckets.' + collName.getName());
+  var cursor = bucketsColl.find({});
+
+  while (cursor.hasNext()) {
+    const bucket = cursor.next();
+    const bucketId = bucket._id;
+    const bucketControlVersion = bucket.control.version;
+    if (bucketHasMismatchedBucketVersion(
+            bucketsColl, bucketId, bucketControlVersion)) {
+      if (bucketControlVersion == BucketVersion.kCompressedSorted) {
+        assert.commandWorked(bucketsColl.updateOne(
+            {_id: bucketId},
+            {$set: {'control.version': BucketVersion.kCompressedUnsorted}}));
+      } else if (bucketControlVersion == BucketVersion.kCompressedUnsorted) {
+        assert.commandWorked(bucketsColl.updateOne(
+            {_id: bucketId},
+            {$set: {'control.version': BucketVersion.kCompressedSorted}}));
+      }
+    }
+  }
+}
+
+runFixBucketVersionMismatchProcedure(collName);

--- a/bucket-version-mismatch/rewrite_timeseries_bucket_version_mismatch.js
+++ b/bucket-version-mismatch/rewrite_timeseries_bucket_version_mismatch.js
@@ -89,4 +89,23 @@ function runFixBucketVersionMismatchProcedure(collName) {
   }
 }
 
+//
+// Steps 1 & 2: Fix the bucket version by updating unsorted v2 buckets to v3
+// buckets and sorted v3 buckets to v2 buckets.
+//
 runFixBucketVersionMismatchProcedure(collName);
+
+//
+// Step 3: Validate that there are no more mismatched bucket versions
+//
+print('Validating that there are no mismatched bucket versions ...\n');
+db.getMongo().setReadPref('secondaryPreferred');
+const validateRes = collName.validate({full: true});
+if (validateRes.errors.length != 0) {
+  print(
+      '\nThere is still a time-series bucket with a bucket version mismatch, or there is another error during validation.');
+  exit(1);
+}
+
+print('\nScript successfully fixed mismatched bucket versions!');
+exit(0);

--- a/bucket-version-mismatch/rewrite_timeseries_bucket_version_mismatch.js
+++ b/bucket-version-mismatch/rewrite_timeseries_bucket_version_mismatch.js
@@ -90,13 +90,13 @@ function runFixBucketVersionMismatchProcedure(collName) {
 }
 
 //
-// Steps 1 & 2: Fix the bucket version by updating unsorted v2 buckets to v3
-// buckets and sorted v3 buckets to v2 buckets.
+// Steps 1 & 2: Detect if the bucket has bucket version mismatch and change the
+// buckets with bucket version mismatch to the correct version.
 //
 runFixBucketVersionMismatchProcedure(collName);
 
 //
-// Step 3: Validate that there are no more mismatched bucket versions
+// Step 3: Validate that there are no bucket version mismatches.
 //
 print('Validating that there are no mismatched bucket versions ...\n');
 db.getMongo().setReadPref('secondaryPreferred');


### PR DESCRIPTION
Tested with these following test cases:
1. The original repro for SERVER-97441 (had the rebuild the server with a commit before SERVER-97441 was merged):
```
// SERVER-94471 repro (this only works before SERVER-97441 was merged).
// Insert two documents near 1-1-1970
const docs = [
    {"t": ISODate("1969-12-31T23:30:30.001Z")},
    {
        "t": ISODate("1970-01-01T00:15:00.001Z"),
    },
]
assert.commandWorked(tsColl.insert(docs))
// Confirm both measurements are in one bucket.
assert.eq(db["system.buckets.ts"].find({}).toArray().length, 1);
let res = tsColl.validate({full: true});
assert(!res.valid);
runFixBucketVersionMismatchProcedure(tsColl);
res = tsColl.validate({full: true});
assert(res.valid);
tsColl.drop();
```

2. Data with sorted v3 buckets (should be remediated)
```
// Create time-series collection
const collName = 'ts';
const tsColl = db[collName];
const bucketsColl = db.getCollection('system.buckets.' + collName);
const timeField = 't';
tsColl.drop();
assert.commandWorked(db.createCollection(collName, {timeseries: {timeField: timeField}}));

// Get the timeField name of the collection
const tsCollInfo = db.runCommand({listCollections: 1, filter: {name: tsColl.getName()}});
const timeFieldName = tsCollInfo["cursor"]["firstBatch"][0]["options"]["timeseries"]["timeField"];

// Validation failure cases.
dataWithSortedv3Buckets = {
    "_id": ObjectId("65a6eb806ffc9fa4280ecac4"),
    "control": {
        "version": BucketVersion.kCompressedUnsorted,
        "min": {
            "_id": ObjectId("65a6eba7e6d2e848e08c3750"),
            "t": ISODate("2024-01-16T20:48:00Z"),
            "a": 0,
        },
        "max": {
            "_id": ObjectId("65a6eba7e6d2e848e08c3751"),
            "t": ISODate("2024-01-16T20:48:39.448Z"),
            "a": 1,
        },
        "count": NumberInt(2),
    },
    "data": {
        "t": BinData(7, "CQAYhggUjQEAAIAOAAAAAAAAAAA="),
        "a": BinData(7, "AQAAAAAAAAAAAJAuAAAAAAAAAAA="),
        "_id": BinData(7, "BwBlpuun5tLoSOCMN1CALgAAAAAAAAAA"),
    }
};
assert.commandWorked(bucketsColl.insert(dataWithSortedv3Buckets));
res = tsColl.validate({full: true});
assert(!res.valid);
print(tojson(res));
runFixBucketVersionMismatchProcedure(tsColl);
res = tsColl.validate({full: true});
print(tojson(res));
assert(res.valid);
tsColl.drop();
```

3. Data with unsorted v2 buckets (should be remediated)
```
assert.commandWorked(db.createCollection(collName, {timeseries: {timeField: timeField}}));
dataWithUnsortedv2Buckets = {
    "_id": ObjectId("630ea4802093f9983fc394dc"),
    "control": {
        "version": BucketVersion.kCompressedSorted,
        "min": {
            "_id": ObjectId("630fabf7c388456f8aea4f2d"),
            "t": ISODate("2022-08-31T00:00:00.000Z"),
            "a": 0
        },
        "max": {
            "_id": ObjectId("630fabf7c388456f8aea4f2f"),
            "t": ISODate("2022-08-31T00:00:01.000Z"),
            "a": 1
        },
        "count": 2
    },
    "data": {
        "t": BinData(7, "CQDolzLxggEAAID+fAAAAAAAAAA="),
        "_id": BinData(7, "BwBjD6v3w4hFb4rqTy2ATgAAAAAAAAAA"),
        "a": BinData(7, "EAAAAAAAgC4AAAAAAAAAAA==")
    }
};
assert.commandWorked(bucketsColl.insert(dataWithUnsortedv2Buckets))
res = tsColl.validate({full: true});
assert(!res.valid);
runFixBucketVersionMismatchProcedure(tsColl);
res = tsColl.validate({full: true});
assert(res.valid);
tsColl.drop();
```

4. Data with unsorted v3 buckets (should not be remediated, tested to ensure no impacts)
```
// Validation pass cases (ensuring that we don't modify correct buckets).
assert.commandWorked(db.createCollection(collName, {timeseries: {timeField: timeField}}));
dataWithUnsortedv3Buckets = {
    "_id": ObjectId("630ea4802093f9983fc394dc"),
    "control": {
        "version": BucketVersion.kCompressedUnsorted,
        "min": {
            "_id": ObjectId("630fabf7c388456f8aea4f2d"),
            "t": ISODate("2022-08-31T00:00:00.000Z"),
            "a": 0
        },
        "max": {
            "_id": ObjectId("630fabf7c388456f8aea4f2f"),
            "t": ISODate("2022-08-31T00:00:01.000Z"),
            "a": 1
        },
        "count": 2
    },
    "data": {
        "t": BinData(7, "CQDolzLxggEAAID+fAAAAAAAAAA="),
        "_id": BinData(7, "BwBjD6v3w4hFb4rqTy2ATgAAAAAAAAAA"),
        "a": BinData(7, "EAAAAAAAgC4AAAAAAAAAAA==")
    }
};
assert.commandWorked(bucketsColl.insert(dataWithUnsortedv3Buckets))
res = tsColl.validate({full: true});
assert(res.valid);
runFixBucketVersionMismatchProcedure(tsColl);
res = tsColl.validate({full: true});
assert(res.valid);
tsColl.drop();
```

5. Data with sorted v2 buckets (should not be remediated, tested to ensure no impacts)
```
assert.commandWorked(db.createCollection(collName, {timeseries: {timeField: timeField}}));
dataWithSortedv2Buckets = {
    "_id": ObjectId("65a6eb806ffc9fa4280ecac4"),
    "control": {
        "version": BucketVersion.kCompressedSorted,
        "min": {
            "_id": ObjectId("65a6eba7e6d2e848e08c3750"),
            "t": ISODate("2024-01-16T20:48:00Z"),
            "a": 0,
        },
        "max": {
            "_id": ObjectId("65a6eba7e6d2e848e08c3751"),
            "t": ISODate("2024-01-16T20:48:39.448Z"),
            "a": 1,
        },
        "count": NumberInt(2),
    },
    "data": {
        "t": BinData(7, "CQAYhggUjQEAAIAOAAAAAAAAAAA="),
        "a": BinData(7, "AQAAAAAAAAAAAJAuAAAAAAAAAAA="),
        "_id": BinData(7, "BwBlpuun5tLoSOCMN1CALgAAAAAAAAAA"),
    }
};
assert.commandWorked(bucketsColl.insert(dataWithSortedv2Buckets))
res = tsColl.validate({full: true});
assert(res.valid);
runFixBucketVersionMismatchProcedure(tsColl);
res = tsColl.validate({full: true});
assert(res.valid);
tsColl.drop();
```