### PR TITLE
SERVER-99669 Make remediation scripts checking for log id 6698300 have distinct methods of checking if issue is remediated

### DIFF
--- a/bucket-version-mismatch/README.md
+++ b/bucket-version-mismatch/README.md
@@ -19,7 +19,7 @@ If you are using these scripts on your own, we strongly recommend:
 -  If running on Atlas:
    - We have already reached out to impacted customers. If we have reached out, you can skip the [Determine if You're Impacted section](#Determine-if-You're-Impacted) and start taking the steps under the [Remediation section](#remediation).
    - Additionally, we recommend using the [Atlas Admin](https://www.mongodb.com/docs/atlas/security-add-mongodb-users/#built-in-roles) role.
-- This script should be run when there are > 1024 events (log lines) since the last call to `validate`.
+- This script uses the `validate` command output to determine if the script has successfully remediated the issue, and false positives can be reported if recent `validate` commands have been executed.
 
 # Determine if You're Impacted
 

--- a/bucket-version-mismatch/README.md
+++ b/bucket-version-mismatch/README.md
@@ -19,6 +19,7 @@ If you are using these scripts on your own, we strongly recommend:
 -  If running on Atlas:
    - We have already reached out to impacted customers. If we have reached out, you can skip the [Determine if You're Impacted section](#Determine-if-You're-Impacted) and start taking the steps under the [Remediation section](#remediation).
    - Additionally, we recommend using the [Atlas Admin](https://www.mongodb.com/docs/atlas/security-add-mongodb-users/#built-in-roles) role.
+- This script should be run when there are > 1024 events (log lines) since the last call to `validate`.
 
 # Determine if You're Impacted
 

--- a/bucket-version-mismatch/README.md
+++ b/bucket-version-mismatch/README.md
@@ -19,7 +19,7 @@ If you are using these scripts on your own, we strongly recommend:
 -  If running on Atlas:
    - We have already reached out to impacted customers. If we have reached out, you can skip the [Determine if You're Impacted section](#Determine-if-You're-Impacted) and start taking the steps under the [Remediation section](#remediation).
    - Additionally, we recommend using the [Atlas Admin](https://www.mongodb.com/docs/atlas/security-add-mongodb-users/#built-in-roles) role.
-- This script uses the `validate` command output to determine if the script has successfully remediated the issue, and false positives can be reported if recent `validate` commands have been executed.
+- This script uses the `validate` command output to determine if the script has successfully remediated the issue. False positives can be reported if recent `validate` commands have been executed.
 
 # Determine if You're Impacted
 

--- a/bucket-version-mismatch/rewrite_timeseries_bucket_version_mismatch.js
+++ b/bucket-version-mismatch/rewrite_timeseries_bucket_version_mismatch.js
@@ -110,13 +110,13 @@ function checkValidateResForBucketVersionMismatch(validateRes) {
 function checkLogsForBucketVersionMismatch() {
   const getLogRes = db.adminCommand({getLog: 'global'});
   if (getLogRes.ok) {
-    result =
-        (getLogRes.log
-             .filter(
-                 line =>
-                     (line.includes('6698300') &&
-                      (line.includes(v2ErrorMsg) || line.includes(v3ErrorMsg))))
-             .length > 0) ?
+    return (getLogRes.log
+                .filter(
+                    line =>
+                        (line.includes('6698300') &&
+                         (line.includes(v2ErrorMsg) ||
+                          line.includes(v3ErrorMsg))))
+                .length > 0) ?
         GetLogResult.successTrue :
         GetLogResult.successFalse;
   }

--- a/bucket-version-mismatch/rewrite_timeseries_bucket_version_mismatch.js
+++ b/bucket-version-mismatch/rewrite_timeseries_bucket_version_mismatch.js
@@ -104,10 +104,13 @@ function checkValidateResForBucketVersionMismatch(validateRes) {
 function checkLogsForBucketVersionMismatch() {
   const getLogRes = db.adminCommand({getLog: 'global'});
   if (getLogRes.ok) {
-    return getLogRes.log.filter(
-        line =>
-            (line.includes('6698300') &&
-             (line.includes(v2ErrorMsg) || line.includes(v3ErrorMsg))));
+    return getLogRes.log
+               .filter(
+                   line =>
+                       (line.includes('6698300') &&
+                        (line.includes(v2ErrorMsg) ||
+                         line.includes(v3ErrorMsg))))
+               .length > 0;
   }
   print(
       '\ngetLog failed. Re-run checkLogsForBucketVersionMismatch() or manually check mongodb logs for validation results.');

--- a/bucket-version-mismatch/rewrite_timeseries_bucket_version_mismatch.js
+++ b/bucket-version-mismatch/rewrite_timeseries_bucket_version_mismatch.js
@@ -146,7 +146,7 @@ if (validateResCheck && logsCheck) {
   exit(1);
 } else if (validateResCheck) {
   print(
-      '\nThere is another error or warning during validation regarding incompatible time-series documents. Check logs with id 6698300.');
+      '\nScript successfully fixed mismatched bucket versions. There is another error or warning during validation regarding incompatible time-series documents. Check logs with id 6698300.');
   exit(0);
 }
 

--- a/bucket-version-mismatch/rewrite_timeseries_bucket_version_mismatch.js
+++ b/bucket-version-mismatch/rewrite_timeseries_bucket_version_mismatch.js
@@ -113,7 +113,7 @@ function checkLogsForBucketVersionMismatch() {
                .length > 0;
   }
   print(
-      '\ngetLog failed. Re-run checkLogsForBucketVersionMismatch() or manually check mongodb logs for validation results.');
+      '\ngetLog failed. Re-run checkLogsForBucketVersionMismatch() or  check mongodb logs for validation results.');
   exit(1);
 }
 
@@ -146,7 +146,7 @@ if (validateResCheck && logsCheck) {
   exit(1);
 } else if (validateResCheck) {
   print(
-      '\nScript successfully fixed mismatched bucket versions. There is another error or warning during validation regarding incompatible time-series documents. Check logs with id 6698300.');
+      '\nScript successfully fixed mismatched bucket versions. There is another error or warning during validation. Check mongodb logs for more details.');
   exit(0);
 }
 

--- a/embedded-timestamp-mismatch/README.md
+++ b/embedded-timestamp-mismatch/README.md
@@ -20,6 +20,7 @@ If you are using these scripts on your own, we strongly recommend:
 -  If running on Atlas:
    - We have already reached out to impacted customers. If we have reached out, you can skip the [Determine if You're Impacted section](#Determine-if-You're-Impacted) and start taking the steps under the [Remediation section](#remediation).
    - Additionally, we recommend using the [Atlas Admin](https://www.mongodb.com/docs/atlas/security-add-mongodb-users/#built-in-roles) role.
+- This script should be run when there are > 1024 events (log lines) since the last call to `validate`.
 
 ## Validation Version Warning
 

--- a/embedded-timestamp-mismatch/README.md
+++ b/embedded-timestamp-mismatch/README.md
@@ -20,7 +20,7 @@ If you are using these scripts on your own, we strongly recommend:
 -  If running on Atlas:
    - We have already reached out to impacted customers. If we have reached out, you can skip the [Determine if You're Impacted section](#Determine-if-You're-Impacted) and start taking the steps under the [Remediation section](#remediation).
    - Additionally, we recommend using the [Atlas Admin](https://www.mongodb.com/docs/atlas/security-add-mongodb-users/#built-in-roles) role.
-- This script should be run when there are > 1024 events (log lines) since the last call to `validate`.
+ - This script uses the `validate` command output to determine if the script has successfully remediated the issue, and false positives can be reported if recent `validate` commands have been executed.
 
 ## Validation Version Warning
 

--- a/embedded-timestamp-mismatch/README.md
+++ b/embedded-timestamp-mismatch/README.md
@@ -20,7 +20,7 @@ If you are using these scripts on your own, we strongly recommend:
 -  If running on Atlas:
    - We have already reached out to impacted customers. If we have reached out, you can skip the [Determine if You're Impacted section](#Determine-if-You're-Impacted) and start taking the steps under the [Remediation section](#remediation).
    - Additionally, we recommend using the [Atlas Admin](https://www.mongodb.com/docs/atlas/security-add-mongodb-users/#built-in-roles) role.
- - This script uses the `validate` command output to determine if the script has successfully remediated the issue, and false positives can be reported if recent `validate` commands have been executed.
+ - This script uses the `validate` command output to determine if the script has successfully remediated the issue. False positives can be reported if recent `validate` commands have been executed.
 
 ## Validation Version Warning
 

--- a/embedded-timestamp-mismatch/rewrite_embedded_bucket_id_control_min_mismatch.js
+++ b/embedded-timestamp-mismatch/rewrite_embedded_bucket_id_control_min_mismatch.js
@@ -198,10 +198,12 @@ function checkValidateResForEmbeddedBucketIdControlMinMismatch(validateRes) {
 function checkLogsForEmbeddedBucketIdControlMinMismatch() {
   const getLogRes = db.adminCommand({getLog: 'global'});
   if (getLogRes.ok) {
-    return getLogRes.log.filter(
-        line =>
-            (line.includes('6698300') &&
-             line.includes(mismatchEmbeddedIdTimestampMsg)));
+    return getLogRes.log
+               .filter(
+                   line =>
+                       (line.includes('6698300') &&
+                        line.includes(mismatchEmbeddedIdTimestampMsg)))
+               .length > 0;
   }
   print(
       '\ngetLog failed. Re-run checkLogsForEmbeddedBucketIdControlMinMismatch() or manually check mongodb logs for validation results.');

--- a/embedded-timestamp-mismatch/rewrite_embedded_bucket_id_control_min_mismatch.js
+++ b/embedded-timestamp-mismatch/rewrite_embedded_bucket_id_control_min_mismatch.js
@@ -246,7 +246,7 @@ if (validateResCheck && logsCheck) {
   exit(1);
 } else if (validateResCheck) {
   print(
-      '\nScript successfully fixed buckets with mismatched embedded bucket id timestamp and control.min timestamp. There is another error or warning during validation regarding incompatible time-series documents. Check logs with id 6698300.');
+      '\nScript successfully fixed buckets with mismatched embedded bucket id timestamp and control.min timestamp. There is another error or warning during validation. Check mongodb logs for more details.');
   exit(0);
 }
 


### PR DESCRIPTION
Uses `getLog` to determine if we have a specific instance of the issue we are remediating for because both embedded timestamp doesn't match the oid and the bucket version mismatch will use log id 6698300 to check if the remediation is successful.

Did testing using the same test case of doing direct bucket writes to insert invalid documents (see [here](https://github.com/mongodb/support-tools/pull/142#issue-2743250297) and [here](https://github.com/mongodb/support-tools/pull/144#issue-2776464369)), checking to see the four cases that could happen are ok:
1. `getLogRes == true`, `validateResCheck == true` -- this would be the error case because we have had it in a getLog and the validateRes, which means the error still is showing up in the logs and we see it in our most recent validateRes
2. `getLogRes == false`, `validateResCheck == true` -- this would mean that we have another issue during validation, but it isn't related to the issue we are remediating for.
3.`getLogRes == true`, `validateResCheck == false` -- the user has run validate before doing this test; this is ok, because we will only raise an error for when `validateResChecm` is also false.
4. `getLogRes == false`, `validateResCheck == false` -- this means that are no issues