### PR TITLE
Adds script for checking CA-118 susceptibility

### DIFF
--- a/ca-118/README.md
+++ b/ca-118/README.md
@@ -1,0 +1,35 @@
+# Check for susceptibility to CA-118
+
+The script `ca-118-check.js` checks a database's susceptibility to CA-118,
+namely that a chunk migration took place within 30 minutes after the
+finishing of a resharding operation. In addition to this condition,
+a retryable write must occur during resharding and be retried after
+resharding in order for the susceptibility to exist. This script cannot
+detect the existence of retryable writes.
+
+CAUTION:
+This check is limited in scope back to the beginning analysis time reported
+by the script. Any events prior to this time that result in susceptibility
+to CA-118 cannot be detected.
+
+To run this check, connect Mongo shell to the config server and then:
+```
+> load("ca-118-check.js")
+> use config
+> isImpactedByCA118(db)
+```
+
+The function will return a list of potentially impacted namespaces
+and print `may be impacted` if the susceptibility exists; otherwise it will
+return an empty list and print `not impacted`.
+
+The function accepts two optional parameters:
+``` javascript
+  isImpactedByCA118(db, timestamps, readPref)
+```
+
+* `timestamps` : boolean, when true, the script displays the namespaces and
+  timestamps of the potentially-impacting reshard operations and chunk
+  migrations. If omitted, defaults to `false`.
+* `readPref` : string, read preference mode for getting documents from the
+  config server. If omitted, defaults to `"secondaryPreferred"`.

--- a/ca-118/ca-118-check-test.js
+++ b/ca-118/ca-118-check-test.js
@@ -1,0 +1,676 @@
+
+load("/home/ubuntu/support-tools/ca-118/ca-118-check.js");
+
+const testCases = [
+  // cases of not impacted:
+  {
+    title: 'no events',
+    endingNumShards: 3,
+    expectedNs: [],
+    docs: [],
+  },
+  {
+    title: 'moveChunk, no resharding',
+    endingNumShards: 3,
+    expectedNs: [],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.000Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_no_reshard',
+        'details': {},
+      },
+    ],
+  },
+  {
+    title: 'resharding, no moveChunk',
+    endingNumShards: 3,
+    expectedNs: [],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.001Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_not_impacted',
+        'details': {'newState': 'committing'},
+      },
+    ],
+  },
+  {
+    title: 'resharding with less than 3 shards, moveChunk',
+    endingNumShards: 2,
+    expectedNs: [],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.001Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_not_impacted',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 2,
+        'time': new Date('2025-01-01T00:00:01.000Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_not_impacted',
+        'details': {},
+      },
+    ],
+  },
+  {
+    title: 'addShard, resharding with less than 3 shards, moveChunk',
+    endingNumShards: 2,
+    expectedNs: [],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.001Z'),
+        'what': 'addShard',
+      },
+      {
+        '_id': 2,
+        'time': new Date('2025-01-01T00:00:01.001Z'),
+        'what': 'addShard',
+      },
+      {
+        '_id': 3,
+        'time': new Date('2025-01-01T00:01:00.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_not_impacted',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 4,
+        'time': new Date('2025-01-01T00:02:00.000Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_not_impacted',
+        'details': {},
+      },
+    ],
+  },
+  {
+    title: 'addShard, removeShard, resharding with less than 3 shards, moveChunk',
+    endingNumShards: 2,
+    expectedNs: [],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.001Z'),
+        'what': 'addShard',
+      },
+      {
+        '_id': 2,
+        'time': new Date('2025-01-01T00:00:01.001Z'),
+        'what': 'addShard',
+      },
+      {
+        '_id': 3,
+        'time': new Date('2025-01-01T00:00:02.001Z'),
+        'what': 'addShard',
+      },
+      {
+        '_id': 4,
+        'time': new Date('2025-01-01T00:00:03.001Z'),
+        'what': 'removeShard',
+      },
+      {
+        '_id': 5,
+        'time': new Date('2025-01-01T00:01:00.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_not_impacted',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 6,
+        'time': new Date('2025-01-01T00:02:00.000Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_not_impacted',
+        'details': {},
+      },
+    ],
+  },
+  {
+    title: 'moveChunk, then resharding',
+    endingNumShards: 3,
+    expectedNs: [],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.000Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_not_impacted',
+        'details': {},
+      },
+      {
+        '_id': 2,
+        'time': new Date('2025-01-01T00:00:00.001Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_not_impacted',
+        'details': {'newState': 'committing'},
+      },
+    ],
+  },
+  {
+    title: 'resharding, then moveChunk outside of interval',
+    endingNumShards: 3,
+    expectedNs: [],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_not_impacted',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 2,
+        'time': new Date('2025-01-01T00:30:00.001Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_not_impacted',
+        'details': {},
+      },
+    ],
+  },
+  {
+    title: 'resharding, then moveChunk in other collection',
+    endingNumShards: 3,
+    expectedNs: [],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_not_impacted',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 2,
+        'time': new Date('2025-01-01T00:00:00.001Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_move_chunk',
+        'details': {},
+      },
+    ],
+  },
+  {
+    title: 'resharding aborted before committing, then moveChunk',
+    endingNumShards: 3,
+    expectedNs: [],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.000Z'),
+        'what': 'reasharding.coordinator.transition',
+        'ns': 'test.coll_not_impacted',
+        'details': {'newState': 'aborting'},
+      },
+      {
+        '_id': 2,
+        'time': new Date('2025-01-01T00:00:00.001Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_move_chunk',
+        'details': {},
+      },
+    ]
+  },
+  {
+    title: 'resharding aborted after committing, then moveChunk',
+    endingNumShards: 3,
+    expectedNs: [],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.000Z'),
+        'what': 'reasharding.coordinator.transition',
+        'ns': 'test.coll_not_impacted',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 2,
+        'time': new Date('2025-01-01T00:00:01.000Z'),
+        'what': 'reasharding.coordinator.transition',
+        'ns': 'test.coll_not_impacted',
+        'details': {'newState': 'aborting'},
+      },
+      {
+        '_id': 3,
+        'time': new Date('2025-01-01T00:00:02.000Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_move_chunk',
+        'details': {},
+      },
+    ]
+  },
+  {
+    title: 'multiple resharding, moveChunk outside of interval',
+    endingNumShards: 3,
+    expectedNs: [],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_not_impacted',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 2,
+        'time': new Date('2025-01-01T01:00:00.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_not_impacted',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 3,
+        'time': new Date('2025-01-01T01:30:00.001Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_not_impacted',
+        'details': {},
+      },
+      {
+        '_id': 4,
+        'time': new Date('2025-01-01T02:00:00.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_not_impacted',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 5,
+        'time': new Date('2025-01-01T02:30:00.001Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_not_impacted',
+        'details': {},
+      },
+      {
+        '_id': 6,
+        'time': new Date('2025-01-01T02:31:00.000Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_not_impacted',
+        'details': {},
+      },
+    ],
+  },
+
+  // cases of may be impacted
+  {
+    title: 'one collection, resharding, moveChunk within interval',
+    endingNumShards: 3,
+    expectedNs: ['test.coll_impacted'],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_impacted',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 2,
+        'time': new Date('2025-01-01T00:00:01.001Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_impacted',
+        'details': {},
+      },
+    ],
+  },
+  {
+    title: 'one collection, resharding, moveChunk on interval border',
+    endingNumShards: 4,
+    expectedNs: ['test.coll_impacted'],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_impacted',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 6,
+        'time': new Date('2025-01-01T00:30:00.000Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_impacted',
+        'details': {},
+      },
+    ],
+  },
+  {
+    title:
+        'one collection, resharding, multiple moveChunk within and outside of interval',
+    endingNumShards: 3,
+    expectedNs: ['test.coll_impacted'],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_impacted',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 2,
+        'time': new Date('2025-01-01T00:01:00.000Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_impacted',
+        'details': {},
+      },
+      {
+        '_id': 3,
+        'time': new Date('2025-01-01T00:02:00.000Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_impacted',
+        'details': {},
+      },
+      {
+        '_id': 4,
+        'time': new Date('2025-01-01T00:30:00.001Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_impacted',
+        'details': {},
+      },
+    ],
+  },
+  {
+    title:
+        'one collection, multiple resharding, moveChunk within interval',
+    endingNumShards: 3,
+    expectedNs: ['test.coll_impacted'],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_impacted',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 2,
+        'time': new Date('2025-01-01T00:00:01.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_impacted',
+        'details': {'newState': 'aborting'},
+      },
+      {
+        '_id': 3,
+        'time': new Date('2025-01-01T00:01:00.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_impacted',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 4,
+        'time': new Date('2025-01-01T00:02:00.000Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_impacted',
+        'details': {},
+      },
+      {
+        '_id': 3,
+        'time': new Date('2025-01-01T00:03:00.000Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_impacted',
+        'details': {},
+      },
+      {
+        '_id': 4,
+        'time': new Date('2025-01-01T00:30:00.001Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_impacted',
+        'details': {},
+      },
+    ],
+  },
+  {
+    title: 'one collection, addShards, resharding, moveChunk within interval',
+    endingNumShards: 3,
+    expectedNs: ['test.coll_impacted'],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.001Z'),
+        'what': 'addShard',
+      },
+      {
+        '_id': 2,
+        'time': new Date('2025-01-01T00:00:01.001Z'),
+        'what': 'addShard',
+      },
+      {
+        '_id': 3,
+        'time': new Date('2025-01-01T00:00:02.001Z'),
+        'what': 'addShard',
+      },
+      {
+        '_id': 4,
+        'time': new Date('2025-01-01T00:01:00.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_impacted',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 5,
+        'time': new Date('2025-01-01T00:01:00.001Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_impacted',
+        'details': {},
+      },
+    ],
+  },
+  {
+    title: 'one collection, removeShards, resharding, moveChunk within interval',
+    endingNumShards: 3,
+    expectedNs: ['test.coll_impacted'],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.001Z'),
+        'what': 'removeShard',
+      },
+      {
+        '_id': 2,
+        'time': new Date('2025-01-01T00:00:01.001Z'),
+        'what': 'removeShard',
+      },
+      {
+        '_id': 3,
+        'time': new Date('2025-01-01T00:00:02.001Z'),
+        'what': 'removeShard',
+      },
+      {
+        '_id': 4,
+        'time': new Date('2025-01-01T00:01:00.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_impacted',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 5,
+        'time': new Date('2025-01-01T00:01:00.001Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_impacted',
+        'details': {},
+      },
+    ],
+  },
+  {
+    title: 'one collection, removeShard, resharding, moveChunk within interval',
+    endingNumShards: 3,
+    expectedNs: ['test.coll_impacted'],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.001Z'),
+        'what': 'removeShard',
+      },
+      {
+        '_id': 4,
+        'time': new Date('2025-01-01T00:01:00.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_impacted',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 5,
+        'time': new Date('2025-01-01T00:01:00.001Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_impacted',
+        'details': {},
+      },
+    ],
+  },
+  {
+    title: 'one collection, addShard, removeShard, resharding, moveChunk within interval',
+    endingNumShards: 4,
+    expectedNs: ['test.coll_impacted'],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.001Z'),
+        'what': 'addShard',
+      },
+      {
+        '_id': 2,
+        'time': new Date('2025-01-01T00:00:01.001Z'),
+        'what': 'removeShard',
+      },
+      {
+        '_id': 2,
+        'time': new Date('2025-01-01T00:00:02.001Z'),
+        'what': 'removeShard',
+      },
+      {
+        '_id': 4,
+        'time': new Date('2025-01-01T00:01:00.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_impacted',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 5,
+        'time': new Date('2025-01-01T00:01:00.001Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_impacted',
+        'details': {},
+      },
+    ],
+  },
+  {
+    title: 'one collection, addShard, removeShards, resharding, moveChunk within interval',
+    endingNumShards: 4,
+    expectedNs: ['test.coll_impacted'],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.001Z'),
+        'what': 'addShard',
+      },
+      {
+        '_id': 2,
+        'time': new Date('2025-01-01T00:00:01.001Z'),
+        'what': 'removeShard',
+      },
+      {
+        '_id': 4,
+        'time': new Date('2025-01-01T00:01:00.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_impacted',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 5,
+        'time': new Date('2025-01-01T00:01:00.001Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_impacted',
+        'details': {},
+      },
+    ],
+  },
+  {
+    title: 'two collections, only one impacted',
+    endingNumShards: 3,
+    expectedNs: ['test.coll_impacted'],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_impacted',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 2,
+        'time': new Date('2025-01-01T00:01:00.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_not_impacted',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 3,
+        'time': new Date('2025-01-01T00:02:00.000Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_impacted',
+        'details': {},
+      },
+      {
+        '_id': 4,
+        'time': new Date('2025-01-02T00:00:00.000Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_not_impacted',
+        'details': {},
+      },
+    ],
+  },
+  {
+    title: 'two collections, both impacted',
+    endingNumShards: 3,
+    expectedNs: ['test.coll_impacted1', 'test.coll_impacted2'],
+    docs: [
+      {
+        '_id': 1,
+        'time': new Date('2025-01-01T00:00:00.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_impacted1',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 2,
+        'time': new Date('2025-01-01T00:01:00.000Z'),
+        'what': 'resharding.coordinator.transition',
+        'ns': 'test.coll_impacted2',
+        'details': {'newState': 'committing'},
+      },
+      {
+        '_id': 3,
+        'time': new Date('2025-01-01T00:02:00.000Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_impacted1',
+        'details': {},
+      },
+      {
+        '_id': 4,
+        'time': new Date('2025-01-01T00:31:00.000Z'),
+        'what': 'moveChunk.commit',
+        'ns': 'test.coll_impacted2',
+        'details': {},
+      },
+    ],
+  },
+
+];
+
+function runTest() {
+  testCases.forEach(function(testCase) {
+    jsTest.log(`Test case: ${testCase.title}`);
+    let retval = _testCA118(testCase.docs, testCase.endingNumShards, true);
+    retval.sort();
+
+    const expected = testCase.expectedNs;
+    expected.sort();
+
+    assert.eq(tojson(retval), tojson(expected), testCase.title);
+    jsTest.log(`passed`);
+  });
+}
+
+runTest();

--- a/ca-118/ca-118-check.js
+++ b/ca-118/ca-118-check.js
@@ -1,0 +1,355 @@
+
+/**
+ * @file ca-118-check.js
+ * This file implements a check for determining a sharded cluster's
+ * susceptibility to CA-118. It returns a list of namespaces that
+ * are potentially impacted. To run this check, start a Mongo shell connected to the config
+ * server and enter
+ *
+ *   load("<path>/ca-118-check.js")
+ *   use config
+ *   nslist = isImpactedByCA118(db)
+ *
+ * nslist will contain a list of namespaces potentially impacted, or an empty
+ * list if no namespaces are impacted. isImpactedByCA118() will also print "may
+ * be impacted" if there are namespaces susceptible to CA-118 or "not impacted"
+ * if no namespaces are impacted.
+ */
+
+const ImpactedIntervalMs = 60000 * 30;  // 30 minutes
+
+/**
+ * For a given ns, this object stores a set of resharding-finish times and
+ * impacted chunk migration times.
+ * @param  finish_time  [optional] resharding finish time
+ */
+class _NsEvents {
+  constructor(finish_time, diffShardCount) {
+    // an associative array indexed by resharding-finish times of arrays
+    // of chunk migration times.
+    this._chunkMigrationTimes = {};
+    // an associative array indexed by resharding-finish times of the
+    // change-in-shard-count. Change-in-shard-count tracks how the shard
+    // count has changed since the beginning of config.changelog.
+    this._diffShardCount = {};
+    this._currentCommittingTime;
+    if (finish_time) {
+      this.addReshardCommittingTime(finish_time, diffShardCount);
+    }
+  }
+
+  getCurrentFinishTime() {
+    return this._currentCommittingTime;
+  }
+
+  isImpacted() {
+    return Object.keys(this._chunkMigrationTimes)
+        .reduce(
+            (accum, time) => Boolean(this._chunkMigrationTimes[time]), false);
+  }
+
+  addReshardCommittingTime(time, shardDiff) {
+    this._diffShardCount[time] = shardDiff;
+    this._currentCommittingTime = time;
+  }
+
+  reshardAborting() {
+    if (this._currentCommittingTime &&
+      this._chunkMigrationTimes[this._currentCommittingTime]) {
+      // Preceeding committing event did not have an impacting chunk migration.
+      this._chunkMigrationTimes[this._currentCommittingTime] = null;
+      this._currentCommittingTime = null;
+    }
+  }
+
+  addChunkMigrationTime(time) {
+    if (this._currentCommittingTime) {
+      if (!Object.keys(this._chunkMigrationTimes).includes(this._currentCommittingTime)) {
+        this._chunkMigrationTimes[this._currentCommittingTime] = new Array;
+      }
+      this._chunkMigrationTimes[this._currentCommittingTime].push(time);
+    }
+  }
+
+  /**
+   * setStartingNumShards() omits impacting moveChunk events for resharding
+   * operations where the number of shards is less than three.
+   * While config.changelog is being read, we only know the number of shards at
+   * the end of the changelog history; we can only determine the number of
+   * shards at the beginning of the changelog history by reading the addShard
+   * and removeShard events in the changelog. Thus, this function is called
+   * after processing the changelog history to cancel the impact of reshard
+   * operations now that the actual number of shards is known.
+   * @param startingNumShards number of shards at the beginning of changelog.
+   */
+  setStartingNumShards(startingNumShards) {
+    Object.keys(this._diffShardCount).forEach((time) => {
+      const numShards = startingNumShards + this._diffShardCount[time];
+      if (numShards < 3 && Object.keys(this._chunkMigrationTimes).includes(time)) {
+        // This resharding operation is not impacted.
+        this._chunkMigrationTimes[time] = null;
+      }
+    });
+  }
+
+  debugString(prefix = '') {
+    let retval = "";
+    const times = this._chunkMigrationTimes;
+    Object.keys(this._chunkMigrationTimes).forEach((reshardTime) => {
+      if (this._chunkMigrationTimes[reshardTime]) {
+        retval = retval + prefix + `reshard commit at:    ${reshardTime}\n`;
+        this._chunkMigrationTimes[reshardTime].forEach(function(migrationTime) {
+          retval = retval + prefix + `  chunk migration at: ${migrationTime}\n`;
+        });
+      }
+    });
+    return retval;
+  }
+}
+
+/**
+ * isImpactedByCA118() checks a sharded cluster for susceptibility to CA-118.
+ * The function returns a list of namespaces where the history of
+ * reshards and chunk migrations indicates susceptibility to CA-118; returns
+ * empty list if there is no susceptibility. The function also prints the
+ * timestamp indicating the start of its analysis, and "may be impacted" if
+ * returning a non-empty list of namespaces or "not impacted" if returning an
+ * empty list.
+ * @param db         config database of the config server.
+ * @param timestamps if true, prints resharding and chunk migration times and
+ *                   namespaces that demonstrate susceptibility.
+ * @param readPref   string indicating read preference mode.
+ * @return list of namespaces possibly impacted by CA-118.
+ */
+function isImpactedByCA118(db, timestamps = false, readPref = "secondaryPreferred") {
+  if (!_prologue(db, readPref)) {
+    return null;
+  }
+
+  const docs = _getChangelogEvents(db.changelog, readPref);
+
+  const endingNumShards = db.shards.countDocuments({});
+  const nsEvents = _processEvents(docs, endingNumShards);
+  const nsImpacted = _namespacesImpacted(nsEvents, timestamps);
+
+  return nsImpacted;
+}
+
+function _prologue(db, readPref) {
+  print('** CA-118 susceptibility check **');
+  const caution =
+      'CAUTION: This script does not determine whether there may have been an\n\
+         impact due to CA-118 prior to this time for this cluster.';
+  const advice =
+      'NOTE 1:  Determining CA-118 susceptibility beyond the history of\n\
+         config.changelog may be possible by examining mongod\n\
+         server logs.\n' + 
+      'NOTE 2:  This script only determines whether a potentially impacting chunk\n\
+         migration occurred after a reshard operation. In addition to this\n\
+         condition, impact due to CA-118 requires a retryable write during\n\
+         resharding that is subsequently retried; this script is not able to\n\
+         check for the presence of retryable write operations.\n' +
+      'For more information: https://jira.mongodb.org/browse/SERVER-89529.';
+  const check_db =
+    'Ensure that you are connected to the config database on the config server.';
+
+  if (db.getName() !== "config") {
+    print("error: db name is not 'config'.");
+    print(check_db);
+    return false;
+  }
+  const collOk = ['changelog', 'shards'].reduce((accum, collName) => {
+    if (!(db.getCollectionNames().includes(collName))) {
+      print(`error: db does not have collection ${collName}`);
+      return false;
+    } else {
+      return accum;
+    }
+  }, true);
+  if (!collOk) {
+    print(check_db);
+    return false;
+  }
+
+  const first = db.changelog.findOne(
+      {}, {time: 1},
+      {sort: {time: 1}, readPreference: readPref, allowDiskUse: true});
+  if (first) {
+    print(`CA-118 analysis begins at ${first.time}`);
+    print(caution);
+    print(advice);
+  } else {
+    print("CA-118 analysis has no events to check (config.changelog is empty).");
+    print(advice);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * _getChangeLogEvents() returns cursor to documents from the collection needed
+ * for CA-118 susceptibility check. The documents are sorted ascending by time
+ * field.
+ * @param  collection Mongo shell collection, should be config.changelog.
+ * @returns cursor over config.changelog documents
+ */
+function _getChangelogEvents(collection, readPref) {
+  // We look for resharding 'committing' state instead of 'done' state
+  // because v5.x and v6.x do not log the 'done' state.
+  const query = {
+    $or: [
+      {what: 'addShard'},
+      {what: 'removeShard'},
+      {
+        $and: [
+          {what: 'resharding.coordinator.transition'},
+          {
+            $or: [
+              {'details.newState': 'aborting'},
+              {'details.newState': 'committing'},
+            ]
+          },
+        ],
+      },
+      {what: 'moveChunk.commit'},
+    ],
+  };
+  const project = {_id: 1, ns: 1, time: 1, what: 1, details: 1};
+  return collection.find(query, project)
+      .readPref(readPref)
+      .sort({time: 1})
+      .allowDiskUse();
+}
+
+/**
+ * _processEvents() returns an array of NsEvents processed from the input.
+ * @param  docs Documents from config.changelog.
+ * @param  endingNumShards Current number of shards (at the end of changelog).
+ * @returns array of NsEvents indexed by namespace.
+ */
+function _processEvents(docs, endingNumShards) {
+  const nsEvents = {};
+
+  let diffShardCount = 0;
+
+  docs.forEach(function(doc) {
+
+    // Reshard operations can transition from other states to 'aborting',
+    // from other states to 'committing', and  from 'committing' to 'aborting'.
+    // Multiple reshard operations cannot overlap each other. We do not have an
+    // event showing that a reshard operation is 'done'; however, chunk
+    // migrations cannot overlap with reshard operations, so the presence of a
+    // chunk migration indicates that a preceding reshard operation either
+    // aborted or finished committing. The following logic shows that we do not
+    // need to track the transitions of multiple resharding operations.
+    //
+    // There are seven combinations of 'aborting' and 'committing' transitions
+    // and chunk migrations that are within the interval of the previous reshard
+    // transition:
+    // 1. reshard operation 1 aborting
+    //    chunk migration within interval
+    //    --> no impact
+    // 2. reshard operation 1 committing
+    //    chunk migration within interval
+    //    --> potential impact
+    // 3. reshard operation 1 aborting
+    //    reshard operation 2 aborting
+    //    chunk migration within interval
+    //    --> no impact
+    // 4. reshard operation 1 committing
+    //    reshard operation 2 committing
+    //    chunk migration within interval
+    //    --> potential impact
+    // 5. reshard operation 1 committing
+    //    reshard operation 1 aborting
+    //    chunk migration within interval
+    //    --> no impact
+    // 6. reshard operation 1 committing
+    //    reshard operation 2 aborting
+    //    chunk migration within interval
+    //    --> no impact
+    // 7. reshard operation 1 aborting
+    //    reshard operation 2 committing
+    //    chunk migration within interval
+    //    --> potential impact
+    //
+    // Other combinations are sequential combinations of the above seven
+    // possibilities. From the above, it follows that there is potential impact
+    // iff chunk migration occurs within the interval following a 'committing'
+    // event without any intervening 'aborting' event. For any 'aborting' event
+    // that is preceded by a 'committing' event, if there is no intervening
+    // chunk migration within interval (that is, no impact), then the preceding
+    // 'committing' event will never cause an impact. Therefore, we only need to
+    // track whether a 'committing' event has a succeeding chunk migration
+    // within interval; we do not need to track individual reshard operation
+    // id's.
+
+    if (doc.what === 'addShard') {
+      diffShardCount += 1;
+    } else if (doc.what === 'removeShard') {
+      diffShardCount += -1;
+    } else if (doc.what === 'resharding.coordinator.transition') {
+      if (doc.details.newState === 'aborting') {
+        if (Object.keys(nsEvents).includes(doc.ns)) {
+          nsEvents[doc.ns].reshardAborting();
+        }
+      } else if (doc.details.newState === 'committing') {
+        if (!Object.keys(nsEvents).includes(doc.ns)) {
+          nsEvents[doc.ns] = new _NsEvents(doc.time, diffShardCount);
+        } else {
+          nsEvents[doc.ns].addReshardCommittingTime(doc.time, diffShardCount);
+        }
+      }
+    } else if (doc.what === 'moveChunk.commit') {
+      if (Object.keys(nsEvents).includes(doc.ns)) {
+        const reshardTime = nsEvents[doc.ns].getCurrentFinishTime();
+        if (reshardTime && doc.time - reshardTime <= ImpactedIntervalMs) {
+          nsEvents[doc.ns].addChunkMigrationTime(doc.time);
+        }
+      }
+    }
+  });
+
+  Object.keys(nsEvents).forEach(function(ns) {
+    nsEvents[ns].setStartingNumShards(endingNumShards - diffShardCount);
+  });
+
+  return nsEvents;
+}
+
+/**
+ * _namespacesImpacted returns the namespaces susceptible to CA-118 using the
+ * events in the input.
+ * @param nsEvents array of NsEvents indexed by namespace.
+ * @returns list of namespaces potentially impacted by CA-118.
+ */
+function _namespacesImpacted(nsEvents, timestamps = false) {
+	let retval = new Array;
+        Object.keys(nsEvents).forEach((ns) => {
+          if (!retval.includes(ns) && nsEvents[ns].isImpacted()) {
+            if (timestamps) {
+              print(`namespace: ${ns}:`);
+              print(nsEvents[ns].debugString("  "));
+            }
+            retval.push(ns);
+          }
+        });
+
+        if (retval.length > 0) {
+          print('result: may be impacted');
+          print('namespaces: ', retval);
+        } else {
+          print('result: not impacted');
+        }
+
+        return retval;
+}
+
+/**
+ * Tests business logic
+ * @param docs Documents from config.changelog
+ * @return list of potentially impacted namespaces
+ */
+function _testCA118(docs, endingNumShards, timestamps = false) {
+	return _namespacesImpacted(_processEvents(docs, endingNumShards), timestamps);
+}


### PR DESCRIPTION
This script examines `config.changelog` to determine if a resharded collection had a chunk migration within 30 minutes following resharding's commit and that the reshard operation occurred in a configuration of 3 or more shards. If so, then the namespace may be impacted by CA-118.