### PR TITLE
MIGRATION-467 Replace deprecated slaveOk logic with mongosh-compatible read preference

### DIFF
--- a/getMongoData/getMongoData.js
+++ b/getMongoData/getMongoData.js
@@ -651,12 +651,19 @@ function printShardOrReplicaSetInfo() {
         return true;
     } else if (state != "standalone" && state != "configsvr") {
         if (state == "SECONDARY" || state == 2) {
-            if (rs.secondaryOk) {
-                rs.secondaryOk();
+            // Detect mongosh (Node-style 'process' exists)
+            const isMongoSh = (typeof process !== 'undefined' &&
+                               process.release && process.release.name === 'node');
+          
+            if (isMongoSh) {
+              // mongosh: avoid deprecation noise
+              db.getMongo().setReadPref("primaryPreferred");
+            } else if (typeof rs !== "undefined" && typeof rs.secondaryOk === "function") {
+              rs.secondaryOk();
             } else {
-                rs.slaveOk();
+              throw new Error("Could not enable reads on secondary in legacy mongo shell");
             }
-        }
+          }
         printReplicaSetInfo();
     }
     return false;


### PR DESCRIPTION
When connected to a secondary, detect whether the shell is mongosh.

- For mongosh, set read preference to primaryPreferred to avoid deprecation warnings.
- For legacy shell, continue to use rs.secondaryOk() if available.
- Remove fallback to slaveOk() and throw explicit error if secondary reads cannot be enabled.

This ensures compatibility with mongosh while preserving legacy shell support.
