### PR TITLE
Add scripts to detect whether a cluster is affected by CA-528 or not

### DIFF
--- a/ca-528/README.md
+++ b/ca-528/README.md
@@ -1,0 +1,172 @@
+# SERVER-85346 Detection Guide
+
+**Purpose:** Determine whether a customer's sharded cluster contains cross-shard duplicate documents caused by SERVER-85346.  
+**Safety:** Both scripts are **read-only**. They do not modify any data and are safe to run on production clusters.
+
+---
+
+## What You Need
+
+- `mongosh` installed locally ([download](https://www.mongodb.com/try/download/shell))
+- The two script files: `find_candidate_collections.js` and `find_duplicates.js`
+- The customer's `mongos` connection string (must connect to **mongos**, not a shard directly)
+
+---
+
+## Overview
+
+The check runs in two steps to avoid running expensive aggregations on collections that cannot be affected.
+
+| Step | Script | Time | What it does |
+|------|--------|------|--------------|
+| 1 | `find_candidate_collections.js` | Seconds | Metadata scan — finds collections that *could* be affected |
+| 2 | `find_duplicates.js` | Minutes to hours | Aggregation — confirms whether duplicates actually exist |
+
+If Step 1 finds no candidates, **stop — the cluster is not affected**. Only proceed to Step 2 for the collections listed by Step 1.
+
+---
+
+## Step 1 — Find Candidate Collections
+
+```bash
+mongosh "mongodb://<mongos-host>:<port>" --quiet -f find_candidate_collections.js
+```
+
+This completes in seconds. It scans index metadata across all sharded collections — no aggregations are run.
+
+### Output: no candidates found
+
+```
+Collections scanned:     12
+Candidate indexes found: 0
+Collections to check:    0
+
+==> No sharded collections with non-simple-collation indexes found.
+```
+
+**The cluster is NOT affected. No further action needed.**
+
+### Output: candidates found
+
+```
+── mydb.orders
+   Shard key: {"customerId":1}
+   Index: name_idx  key: {"customerId":1,"name":1}  unique: yes  collation: {"locale":"en_US","strength":2}
+
+Collections scanned:     12
+Candidate indexes found: 1
+Collections to check:    1
+
+==> Run find_duplicates.js to check these collection(s) for actual duplicates.
+```
+
+**One or more collections need to be checked. Proceed to Step 2.**
+
+Note down the namespace(s) listed (format: `database.collection`). You will use them in Step 2.
+
+---
+
+## Step 2 — Check for Actual Duplicates
+
+Run this once per candidate collection identified in Step 1. Targeting one collection at a time is strongly recommended — it gives clearer output and lets you stop as soon as you find an affected collection.
+
+### Check a single collection (recommended)
+
+Replace `mydb.orders` with the namespace from Step 1:
+
+```bash
+mongosh "mongodb://<mongos-host>:<port>" \
+  --eval 'const TARGET_NS="mydb.orders";' \
+  --quiet -f find_duplicates.js
+```
+
+### Check all candidate collections at once
+
+```bash
+mongosh "mongodb://<mongos-host>:<port>" --quiet -f find_duplicates.js
+```
+
+> **Note:** On large collections this aggregation can take a long time and consume significant server resources. Check with the customer before running on a busy cluster.
+
+### Output: no duplicates
+
+```
+Duplicate groups found:   0
+
+==> No cross-shard collation duplicates found.
+```
+
+Exit code: `0`. **This collection is NOT affected.**
+
+### Output: duplicates found
+
+```
+   Index: name_idx
+     Collation: {"locale":"en_US","strength":2}
+     Result: 2 duplicate group(s) found:
+
+       Key values: {"name":"John Smith"}
+       Count:      2
+       Sample _ids: [ObjectId("665a1b..."), ObjectId("665a1c...")]
+
+Duplicate groups found:   2
+Affected collections:     mydb.orders
+
+==> DUPLICATES DETECTED — this cluster is affected by SERVER-85346.
+```
+
+Exit code: `1`. **This collection IS affected.** See [What to Collect](#what-to-collect-when-affected) below.
+
+---
+
+## Verdict Summary
+
+| Step 1 result | Step 2 result | Verdict |
+|---------------|---------------|---------|
+| No candidates | — | **NOT AFFECTED** |
+| Candidates found | No duplicates in any | **NOT AFFECTED** |
+| Candidates found | Duplicates in at least one | **AFFECTED** |
+
+---
+
+## What to Collect When Affected
+
+Before closing the session, capture the full output of both scripts:
+
+```bash
+mongosh "mongodb://<mongos-host>:<port>" --quiet -f find_candidate_collections.js \
+  | tee find_candidate_collections_output.txt
+
+mongosh "mongodb://<mongos-host>:<port>" --quiet -f find_duplicates.js \
+  | tee find_duplicates_output.txt
+```
+
+The output includes:
+- The affected namespace(s)
+- The index name, key, and collation
+- The number of duplicate groups
+- Sample `_id` values for each group
+
+Attach both `.txt` files to the support case.
+
+---
+
+## Troubleshooting
+
+**"command not found: mongosh"**  
+Download mongosh from https://www.mongodb.com/try/download/shell and ensure it is on your `PATH`, or prefix every command with the full path:
+```bash
+/path/to/mongosh "mongodb://..." --quiet -f find_candidate_collections.js
+```
+
+**"Authentication failed" or "not authorized"**  
+The user needs at least `read` on all databases and `read` on the `config` database. Ask the customer to connect with a user that has the built-in `readAnyDatabase` role (or `clusterMonitor`).
+
+**Connection times out / cannot connect**  
+Confirm the customer is providing the `mongos` address and port, not a shard or config server address. The scripts query `config.collections` which is only accessible via mongos.
+
+**Step 2 runs for a very long time**  
+The aggregation scans every document in the collection. On multi-terabyte collections this is expected. Use `TARGET_NS` to run one collection at a time so you can report partial results. Ask the customer if there is a maintenance window available.
+
+**WARNING lines in the output**  
+Lines like `WARNING: could not list indexes for db.coll` mean that collection was skipped. Note them in the case but they do not affect the verdict for other collections.

--- a/ca-528/README.md
+++ b/ca-528/README.md
@@ -105,7 +105,7 @@ Exit code: `0`. **This collection is NOT affected.**
      Collation: {"locale":"en_US","strength":2}
      Result: 2 duplicate group(s) found:
 
-       Key values: {"name":"John Smith"}
+       Key values: {"customerId": 123, "name":"John Smith"}
        Count:      2
        Sample _ids: [ObjectId("665a1b..."), ObjectId("665a1c...")]
 

--- a/ca-528/find_candidate_collections.js
+++ b/ca-528/find_candidate_collections.js
@@ -1,0 +1,104 @@
+// find_candidate_collections.js
+// Step 1 of 2: Fast metadata-only scan to find sharded collections that may be
+// affected by SERVER-85346 (non-simple-collation unique indexes). No aggregations
+// are run — completes in seconds even on large clusters.
+//
+// Run Step 2 (find_duplicates.js) against the collections listed here.
+//
+// Usage:
+//   mongosh "mongodb://127.0.0.1:27017" --quiet -f find_candidate_collections.js
+
+(function () {
+    "use strict";
+
+    const configDB = db.getSiblingDB("config");
+
+    function isNonSimpleCollation(c) {
+        if (!c) return false;
+        if (c.locale === "simple" || c.locale === undefined) return false;
+        return true;
+    }
+
+    const shardedColls = configDB.collections.find({
+        dropped: { $ne: true },
+        key: { $exists: true }
+    }).toArray();
+
+    print("Scanning " + shardedColls.length + " sharded collection(s) for candidate indexes...\n");
+
+    let totalCandidateIndexes = 0;
+    const candidateNss = [];
+
+    for (const collDoc of shardedColls) {
+        const nss = collDoc._id || collDoc.ns;
+        if (!nss) continue;
+
+        const dotIdx   = nss.indexOf(".");
+        const dbName   = nss.substring(0, dotIdx);
+        const collName = nss.substring(dotIdx + 1);
+        if (!dbName || !collName) continue;
+
+        if (["config", "admin", "local"].includes(dbName)) continue;
+
+        const shardKey = collDoc.key;
+        const targetDB = db.getSiblingDB(dbName);
+        const coll     = targetDB.getCollection(collName);
+
+        let collDefaultCollation = null;
+        try {
+            const collInfo = targetDB.getCollectionInfos({ name: collName });
+            if (collInfo.length > 0 && collInfo[0].options && collInfo[0].options.collation) {
+                collDefaultCollation = collInfo[0].options.collation;
+            }
+        } catch (e) {
+            print("WARNING: could not get collection info for " + nss + ": " + e);
+            continue;
+        }
+
+        let indexes;
+        try {
+            indexes = coll.getIndexes();
+        } catch (e) {
+            print("WARNING: could not list indexes for " + nss + ": " + e);
+            continue;
+        }
+
+        const candidateIndexes = indexes.filter(idx => {
+            const eff = idx.collation || collDefaultCollation || null;
+            return isNonSimpleCollation(eff);
+        });
+
+        if (candidateIndexes.length === 0) continue;
+
+        totalCandidateIndexes += candidateIndexes.length;
+        candidateNss.push(nss);
+
+        print("── " + nss);
+        print("   Shard key: " + EJSON.stringify(shardKey));
+        candidateIndexes.forEach(idx => {
+            const eff = idx.collation || collDefaultCollation;
+            print("   Index: " + idx.name
+                + "  key: " + EJSON.stringify(idx.key)
+                + "  unique: " + (idx.unique ? "yes" : "no")
+                + "  collation: " + EJSON.stringify(eff));
+        });
+        print("");
+    }
+
+    print("============================================================");
+    print("Collections scanned:     " + shardedColls.length);
+    print("Candidate indexes found: " + totalCandidateIndexes);
+    print("Collections to check:    " + candidateNss.length);
+
+    if (candidateNss.length > 0) {
+        print("");
+        print("==> Run find_duplicates.js to check these collection(s) for actual duplicates.");
+        print("    To check a single collection, pass TARGET_NS before the script:");
+        print("    mongosh <uri> --eval 'const TARGET_NS=\"db.coll\";' -f find_duplicates.js");
+        quit(0);
+    } else {
+        print("");
+        print("==> No sharded collections with non-simple-collation indexes found.");
+        quit(0);
+    }
+})();

--- a/ca-528/find_candidate_collections.js
+++ b/ca-528/find_candidate_collections.js
@@ -19,6 +19,13 @@
         return true;
     }
 
+    function shardKeyIsPrefix(shardKey, indexKey) {
+        const skFields = Object.keys(shardKey);
+        const ixFields = Object.keys(indexKey);
+        if (skFields.length > ixFields.length) return false;
+        return skFields.every((f, i) => ixFields[i] === f);
+    }
+
     const shardedColls = configDB.collections.find({
         dropped: { $ne: true },
         key: { $exists: true }
@@ -65,7 +72,7 @@
 
         const candidateIndexes = indexes.filter(idx => {
             const eff = idx.collation || collDefaultCollation || null;
-            return isNonSimpleCollation(eff);
+            return isNonSimpleCollation(eff) && idx.unique && shardKeyIsPrefix(shardKey, idx.key);
         });
 
         if (candidateIndexes.length === 0) continue;

--- a/ca-528/find_duplicates.js
+++ b/ca-528/find_duplicates.js
@@ -1,0 +1,188 @@
+// find_duplicates.js
+// Step 2 of 2: For each candidate collection found by find_candidate_collections.js,
+// run the expensive aggregation to detect actual cross-shard duplicates caused by
+// SERVER-85346 (non-simple-collation unique indexes on sharded collections).
+//
+// Usage (all candidate collections):
+//   mongosh "mongodb://127.0.0.1:27017" --quiet -f find_duplicates.js
+//
+// Usage (single collection — much faster on large clusters):
+//   mongosh "mongodb://127.0.0.1:27017" --eval 'const TARGET_NS="mydb.mycoll";' -f find_duplicates.js
+
+(function () {
+    "use strict";
+
+    const MAX_DUP_GROUPS = 100;   // max duplicate groups to report per index
+    const SAMPLE_IDS_PER = 5;     // sample _ids shown per group
+
+    // Optional: set via --eval 'const TARGET_NS="db.coll";' to scan one collection only.
+    const targetNs = (typeof TARGET_NS !== "undefined") ? TARGET_NS : null;
+
+    const configDB = db.getSiblingDB("config");
+
+    function isNonSimpleCollation(c) {
+        if (!c) return false;
+        if (c.locale === "simple" || c.locale === undefined) return false;
+        return true;
+    }
+
+    let shardedColls = configDB.collections.find({
+        dropped: { $ne: true },
+        key: { $exists: true }
+    }).toArray();
+
+    if (targetNs) {
+        shardedColls = shardedColls.filter(c => (c._id || c.ns) === targetNs);
+        if (shardedColls.length === 0) {
+            print("ERROR: namespace '" + targetNs + "' not found in config.collections.");
+            quit(1);
+        }
+        print("Scanning 1 collection (TARGET_NS=" + targetNs + ") for duplicates...\n");
+    } else {
+        print("Scanning " + shardedColls.length + " sharded collection(s) for duplicates...\n");
+        print("Tip: run find_candidate_collections.js first to identify specific collections,");
+        print("     then target one with: --eval 'const TARGET_NS=\"db.coll\";' -f find_duplicates.js\n");
+    }
+
+    let totalCandidateIndexes = 0;
+    let totalDuplicateGroups  = 0;
+    const affectedCollections = [];
+
+    for (const collDoc of shardedColls) {
+        const nss = collDoc._id || collDoc.ns;
+        if (!nss) continue;
+
+        const dotIdx   = nss.indexOf(".");
+        const dbName   = nss.substring(0, dotIdx);
+        const collName = nss.substring(dotIdx + 1);
+        if (!dbName || !collName) continue;
+
+        if (!targetNs && ["config", "admin", "local"].includes(dbName)) continue;
+
+        const shardKey = collDoc.key;
+        const targetDB = db.getSiblingDB(dbName);
+        const coll     = targetDB.getCollection(collName);
+
+        let collDefaultCollation = null;
+        try {
+            const collInfo = targetDB.getCollectionInfos({ name: collName });
+            if (collInfo.length > 0 && collInfo[0].options && collInfo[0].options.collation) {
+                collDefaultCollation = collInfo[0].options.collation;
+            }
+        } catch (e) {
+            print("WARNING: could not get collection info for " + nss + ": " + e);
+            continue;
+        }
+
+        let indexes;
+        try {
+            indexes = coll.getIndexes();
+        } catch (e) {
+            print("WARNING: could not list indexes for " + nss + ": " + e);
+            continue;
+        }
+
+        const candidates = indexes.filter(idx => {
+            const eff = idx.collation || collDefaultCollation || null;
+            return isNonSimpleCollation(eff);
+        });
+
+        if (candidates.length === 0) continue;
+
+        totalCandidateIndexes += candidates.length;
+        print("── Collection: " + nss);
+        print("   Shard key: " + EJSON.stringify(shardKey));
+        print("   " + candidates.length + " candidate index(es)\n");
+
+        let collDuplicates = 0;
+
+        candidates.forEach(idx => {
+            const effCollation = idx.collation || collDefaultCollation;
+            const keyFields    = Object.keys(idx.key);
+
+            print("   Index: " + idx.name);
+            print("     Key:       " + EJSON.stringify(idx.key));
+            print("     Unique:    " + (idx.unique ? "yes" : "no (may have been made unique via collMod on shards)"));
+            print("     Collation: " + EJSON.stringify(effCollation));
+
+            const projectSpec = { _id: 1 };
+            keyFields.forEach(f => { projectSpec[f] = 1; });
+
+            const shardKeyFields = new Set(Object.keys(shardKey));
+            const suffixFields = keyFields.filter(f => !shardKeyFields.has(f));
+
+            const groupId = {};
+            if (suffixFields.length > 0) {
+                suffixFields.forEach(f => { groupId[f] = "$" + f; });
+            } else {
+                keyFields.forEach(f => { groupId[f] = "$" + f; });
+            }
+
+            const pipeline = [
+                { $project: projectSpec },
+                {
+                    $group: {
+                        _id: groupId,
+                        count: { $sum: 1 },
+                        sampleIds: { $push: "$_id" }
+                    }
+                },
+                { $match: { count: { $gt: 1 } } },
+                {
+                    $project: {
+                        count: 1,
+                        sampleIds: { $slice: ["$sampleIds", SAMPLE_IDS_PER] }
+                    }
+                },
+                { $limit: MAX_DUP_GROUPS }
+            ];
+
+            let dupGroups;
+            try {
+                dupGroups = coll.aggregate(pipeline, {
+                    allowDiskUse: true,
+                    collation: effCollation
+                }).toArray();
+            } catch (e) {
+                print("     ERROR running duplicate aggregation: " + e + "\n");
+                return;
+            }
+
+            if (dupGroups.length === 0) {
+                print("     Result: NO duplicates found.\n");
+            } else {
+                collDuplicates += dupGroups.length;
+                print("     Result: " + dupGroups.length + " duplicate group(s) found"
+                      + (dupGroups.length >= MAX_DUP_GROUPS ? " (capped)" : "")
+                      + ":\n");
+                dupGroups.forEach(g => {
+                    print("       Key values: " + EJSON.stringify(g._id));
+                    print("       Count:      " + g.count);
+                    print("       Sample _ids: " + EJSON.stringify(g.sampleIds));
+                    print("");
+                });
+            }
+        });
+
+        if (collDuplicates > 0) {
+            totalDuplicateGroups += collDuplicates;
+            affectedCollections.push(nss);
+        }
+    }
+
+    print("============================================================");
+    print("Collections scanned:      " + (targetNs ? 1 : shardedColls.length));
+    print("Candidate indexes found:  " + totalCandidateIndexes);
+    print("Duplicate groups found:   " + totalDuplicateGroups);
+
+    if (totalDuplicateGroups > 0) {
+        print("Affected collections:     " + affectedCollections.join(", "));
+        print("");
+        print("==> DUPLICATES DETECTED — this cluster is affected by SERVER-85346.");
+        quit(1);
+    } else {
+        print("");
+        print("==> No cross-shard collation duplicates found.");
+        quit(0);
+    }
+})();

--- a/ca-528/find_duplicates.js
+++ b/ca-528/find_duplicates.js
@@ -26,6 +26,13 @@
         return true;
     }
 
+    function shardKeyIsPrefix(shardKey, indexKey) {
+        const skFields = Object.keys(shardKey);
+        const ixFields = Object.keys(indexKey);
+        if (skFields.length > ixFields.length) return false;
+        return skFields.every((f, i) => ixFields[i] === f);
+    }
+
     let shardedColls = configDB.collections.find({
         dropped: { $ne: true },
         key: { $exists: true }
@@ -84,7 +91,7 @@
 
         const candidates = indexes.filter(idx => {
             const eff = idx.collation || collDefaultCollation || null;
-            return isNonSimpleCollation(eff);
+            return isNonSimpleCollation(eff) && idx.unique && shardKeyIsPrefix(shardKey, idx.key);
         });
 
         if (candidates.length === 0) continue;
@@ -108,15 +115,8 @@
             const projectSpec = { _id: 1 };
             keyFields.forEach(f => { projectSpec[f] = 1; });
 
-            const shardKeyFields = new Set(Object.keys(shardKey));
-            const suffixFields = keyFields.filter(f => !shardKeyFields.has(f));
-
             const groupId = {};
-            if (suffixFields.length > 0) {
-                suffixFields.forEach(f => { groupId[f] = "$" + f; });
-            } else {
-                keyFields.forEach(f => { groupId[f] = "$" + f; });
-            }
+            keyFields.forEach(f => { groupId[f] = "$" + f; });
 
             const pipeline = [
                 { $project: projectSpec },


### PR DESCRIPTION
This PR adds two scripts:

`find_candidate_collections.js` Metadata scan — finds collections that could be affected
`find_duplicates.js` Aggregation — confirms whether duplicates actually exist

To detect wheter you might or are affected by CA-528. The main reason it's two script is because the second script does a collection scan with an aggregation, so, the idea is that a customer that is not sure it might be affected can run the first script to check for the metadata of all the collections and find whether the cluster might be affected or not.