### PR TITLE
Add Planner Settings Checker tool to migration toolbox

### DIFF
--- a/migration/toolbox/README.md
+++ b/migration/toolbox/README.md
@@ -26,6 +26,10 @@ Get busiest collections seen during Collection Copy and Change Event Application
 
 Gets the busiest collections in terms of writes (delete/insert/replace/update) as recorded in the mongosync logs in the CEA phase
 
+## [Planner Settings Checker](plannerSettingsChecker)
+
+Audits query planner customizations across all databases and collections, reporting only the namespaces where a setting is present. Supports two modes: `indexFilters` (legacy `planCacheListFilters`, all versions) and `querySettings` (the `$querySettings` aggregation, MongoDB 8.0+). Useful as a pre-migration check so planner customizations can be reviewed and re-created on the destination. For full documentation and examples, see [plannerSettingsChecker README](plannerSettingsChecker/README.md).
+
 ### License
 
 [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/migration/toolbox/plannerSettingsChecker/README.md
+++ b/migration/toolbox/plannerSettingsChecker/README.md
@@ -7,10 +7,10 @@ identified, reviewed, and (where appropriate) re-created on the destination clus
 
 It runs in one of two modes:
 
-| Mode            | Mechanism                         | Applies to                                   |
-| --------------- | --------------------------------- | -------------------------------------------- |
-| `indexFilters`  | `planCacheListFilters` command    | Legacy index filters (all supported versions)|
-| `querySettings` | `$querySettings` aggregation stage | Query settings (**MongoDB 8.0+**)           |
+| Mode | Mechanism | Applies to |
+| --- | --- | --- |
+| `indexFilters` | `planCacheListFilters` command | Legacy index filters (all supported versions) |
+| `querySettings` | `$querySettings` aggregation stage | Query settings (**MongoDB 8.0+**) |
 
 > **Why both?** Index filters are the legacy mechanism for constraining the query
 > planner. Query settings are their modern, persistent replacement introduced in
@@ -47,7 +47,7 @@ results.
   "generatedAt": "2026-06-11T00:00:00.000Z",
   "host": "cluster0-shard-00-00.example.mongodb.net:27017",
   "mode": "indexFilters",
-  "summary": { "collectionsWithIndexFilters": 1 },
+  "summary": { "collectionsWithIndexFilters": 1, "errorCount": 0 },
   "results": [
     {
       "db": "mydb",
@@ -57,7 +57,8 @@ results.
       "indexFilterCount": 1,
       "indexFilters": [ { "query": { "email": 1 }, "indexes": [ { "email": 1 } ] } ]
     }
-  ]
+  ],
+  "errors": []
 }
 ```
 

--- a/migration/toolbox/plannerSettingsChecker/README.md
+++ b/migration/toolbox/plannerSettingsChecker/README.md
@@ -1,0 +1,116 @@
+# Planner Settings Checker
+
+This script collects MongoDB **query planner customizations** across all databases and
+collections in a deployment and reports only the namespaces where a setting is actually
+present. It is intended as a **pre-migration audit** so that planner customizations are
+identified, reviewed, and (where appropriate) re-created on the destination cluster.
+
+It runs in one of two modes:
+
+| Mode            | Mechanism                         | Applies to                                   |
+| --------------- | --------------------------------- | -------------------------------------------- |
+| `indexFilters`  | `planCacheListFilters` command    | Legacy index filters (all supported versions)|
+| `querySettings` | `$querySettings` aggregation stage | Query settings (**MongoDB 8.0+**)           |
+
+> **Why both?** Index filters are the legacy mechanism for constraining the query
+> planner. Query settings are their modern, persistent replacement introduced in
+> MongoDB 8.0. Depending on the source server version, planner customizations may live
+> in one or the other.
+
+---
+
+## What the script does
+
+### `indexFilters` mode (default)
+
+1. Enumerates every database via `getDBs()`.
+2. For each database, lists non-system collections (skips `system.*` and the internal
+   `local` collections).
+3. Runs `planCacheListFilters` against each collection.
+4. Returns **only** collections that have one or more index filters set.
+
+### `querySettings` mode
+
+1. Runs a single `$querySettings` aggregation against the `admin` database.
+2. Groups the returned settings by namespace (`db.collection`).
+3. Returns the per-namespace settings.
+
+### Output
+
+Prints a JSON report including a timestamp, host, mode, a summary count, and the matching
+results.
+
+**Sample `indexFilters` output:**
+
+```json
+{
+  "generatedAt": "2026-06-11T00:00:00.000Z",
+  "host": "cluster0-shard-00-00.example.mongodb.net:27017",
+  "mode": "indexFilters",
+  "summary": { "collectionsWithIndexFilters": 1 },
+  "results": [
+    {
+      "db": "mydb",
+      "collection": "users",
+      "namespace": "mydb.users",
+      "hasIndexFilters": true,
+      "indexFilterCount": 1,
+      "indexFilters": [ { "query": { "email": 1 }, "indexes": [ { "email": 1 } ] } ]
+    }
+  ]
+}
+```
+
+---
+
+## Usage
+
+```bash
+# Index filters (default)
+mongosh "<connection-string>" --quiet --eval 'var _mode="indexFilters"' get-planner-settings.js
+
+# Query settings (MongoDB 8.0+)
+mongosh "<connection-string>" --quiet --eval 'var _mode="querySettings"' get-planner-settings.js
+```
+
+If `_mode` is omitted it defaults to `indexFilters`. An invalid value prints usage and
+exits with a non-zero code.
+
+---
+
+## Requirements
+
+- **`indexFilters`**: privileges to enumerate databases/collections and run
+  `planCacheListFilters` on the target collections.
+- **`querySettings`**: MongoDB **8.0+** and cluster-admin level privileges to run the
+  `$querySettings` aggregation against `admin`.
+
+Per-database or per-collection errors (for example, due to restricted privileges) are
+captured and skipped gracefully rather than aborting the run.
+
+---
+
+## Notes
+
+- The script is **read-only**. It only issues diagnostic commands and does not modify any
+  planner settings, indexes, or data.
+- On clusters with a very large number of collections, `indexFilters` mode issues one
+  command per collection; the run is lightweight but may take time at scale.
+
+DISCLAIMER
+----------
+Please note: all tools/ scripts in this repo are released for use "AS IS" **without any warranties of any kind**,
+including, but not limited to their installation, use, or performance.  We disclaim any and all warranties, either 
+express or implied, including but not limited to any warranty of noninfringement, merchantability, and/ or fitness 
+for a particular purpose.  We do not warrant that the technology will meet your requirements, that the operation 
+thereof will be uninterrupted or error-free, or that any errors will be corrected.
+
+Any use of these scripts and tools is **at your own risk**.  There is no guarantee that they have been through 
+thorough testing in a comparable environment and we are not responsible for any damage or data loss incurred with 
+their use.
+
+You are responsible for reviewing and testing any scripts you run *thoroughly* before use in any non-testing 
+environment.
+
+Thanks,  
+The MongoDB Support Team

--- a/migration/toolbox/plannerSettingsChecker/get-planner-settings.js
+++ b/migration/toolbox/plannerSettingsChecker/get-planner-settings.js
@@ -1,0 +1,288 @@
+/* global db, print, printjson, quit, _mode */
+
+/*
+ * get-planner-settings.js
+ *
+ * Collect either:
+ *   - index filters
+ *   - query settings
+ *
+ * This script only returns collections/namespaces where a positive result exists.
+ *
+ * Set mode with:
+ *   mongosh --quiet --eval 'var _mode="indexFilters"' get-planner-settings.js
+ *   mongosh --quiet --eval 'var _mode="querySettings"' get-planner-settings.js
+ *
+ * Optional values:
+ *   _mode = "indexFilters"   // default
+ *   _mode = "querySettings"
+ *
+ * Notes:
+ *   - "indexFilters" uses planCacheListFilters (legacy mechanism, all versions).
+ *   - "querySettings" uses the $querySettings aggregation stage and requires
+ *     MongoDB 8.0+ and cluster-admin level privileges.
+ */
+
+// Resolve the mode BEFORE entering the strict-mode IIFE. Assigning to an
+// undeclared identifier inside "use strict" throws a ReferenceError, so the
+// default must be established here on the global object.
+if (typeof _mode === "undefined") {
+    globalThis._mode = "indexFilters";
+}
+
+(function () {
+    "use strict";
+
+    function getCollectionNames(database) {
+        var collectionNames = [];
+
+        database.getCollectionInfos({ "type": "collection" }).forEach(function (collectionInfo) {
+            var name = collectionInfo.name;
+
+            if (name.indexOf("system.") === 0) {
+                return;
+            }
+
+            if (database.getName() === "local") {
+                if (name === "startup_log" || name.indexOf("replset.") === 0) {
+                    return;
+                }
+            }
+
+            collectionNames.push(name);
+        });
+
+        return collectionNames;
+    }
+
+    function getCollectionIndexFilters(database, collectionName) {
+        var res = {
+            db: database.getName(),
+            collection: collectionName,
+            namespace: database.getName() + "." + collectionName,
+            hasIndexFilters: false,
+            indexFilterCount: 0,
+            indexFilters: []
+        };
+
+        try {
+            var cmd = database.runCommand({
+                planCacheListFilters: collectionName
+            });
+
+            if (!cmd.ok) {
+                res.error = cmd;
+                return res;
+            }
+
+            if (cmd.filters && Array.isArray(cmd.filters)) {
+                res.indexFilters = cmd.filters;
+            } else if (cmd.indexFilters && Array.isArray(cmd.indexFilters)) {
+                res.indexFilters = cmd.indexFilters;
+            }
+
+            res.indexFilterCount = res.indexFilters.length;
+            res.hasIndexFilters = res.indexFilterCount > 0;
+        } catch (e) {
+            res.error = e.message;
+        }
+
+        return res;
+    }
+
+    function getAllQuerySettings() {
+        var res = {
+            ok: false,
+            querySettings: []
+        };
+
+        try {
+            var cmd = db.adminCommand({
+                aggregate: 1,
+                pipeline: [
+                    { $querySettings: {} }
+                ],
+                cursor: {}
+            });
+
+            if (!cmd.ok) {
+                res.error = cmd;
+                return res;
+            }
+
+            if (cmd.cursor && cmd.cursor.firstBatch) {
+                res.querySettings = cmd.cursor.firstBatch;
+            }
+
+            res.ok = true;
+        } catch (e) {
+            res.error = e.message;
+        }
+
+        return res;
+    }
+
+    function buildNamespaceMap(querySettings) {
+        var namespaceMap = {};
+
+        querySettings.forEach(function (entry) {
+            var ns = null;
+
+            if (entry.namespace) {
+                ns = entry.namespace;
+            } else if (entry.representativeQuery && entry.representativeQuery.namespace) {
+                ns = entry.representativeQuery.namespace;
+            }
+
+            if (!ns) {
+                ns = "unknown";
+            }
+
+            if (!namespaceMap[ns]) {
+                namespaceMap[ns] = [];
+            }
+
+            namespaceMap[ns].push(entry);
+        });
+
+        return namespaceMap;
+    }
+
+    function collectIndexFilters() {
+        var allResults = [];
+        var dbs = db.getMongo().getDBs();
+
+        if (!dbs.databases) {
+            return allResults;
+        }
+
+        dbs.databases.forEach(function (dbInfo) {
+            var database = db.getSiblingDB(dbInfo.name);
+            var collections;
+
+            try {
+                collections = getCollectionNames(database);
+            } catch (e) {
+                return;
+            }
+
+            collections.forEach(function (collectionName) {
+                var result = getCollectionIndexFilters(database, collectionName);
+
+                if (result.hasIndexFilters) {
+                    allResults.push(result);
+                }
+            });
+        });
+
+        return allResults;
+    }
+
+    function collectQuerySettings() {
+        var allResults = [];
+        var allQuerySettingsResult = getAllQuerySettings();
+
+        if (!allQuerySettingsResult.ok) {
+            return {
+                error: allQuerySettingsResult.error,
+                results: []
+            };
+        }
+
+        var namespaceMap = buildNamespaceMap(allQuerySettingsResult.querySettings);
+
+        Object.keys(namespaceMap).forEach(function (namespace) {
+            if (namespace === "unknown") {
+                allResults.push({
+                    namespace: namespace,
+                    hasQuerySettings: true,
+                    querySettingsCount: namespaceMap[namespace].length,
+                    querySettings: namespaceMap[namespace]
+                });
+                return;
+            }
+
+            var firstDot = namespace.indexOf(".");
+            var dbName;
+            var collectionName;
+
+            if (firstDot === -1) {
+                dbName = namespace;
+                collectionName = "";
+            } else {
+                dbName = namespace.substring(0, firstDot);
+                collectionName = namespace.substring(firstDot + 1);
+            }
+
+            allResults.push({
+                db: dbName,
+                collection: collectionName,
+                namespace: namespace,
+                hasQuerySettings: true,
+                querySettingsCount: namespaceMap[namespace].length,
+                querySettings: namespaceMap[namespace]
+            });
+        });
+
+        return {
+            totalQuerySettingsReturned: allQuerySettingsResult.querySettings.length,
+            results: allResults
+        };
+    }
+
+    function printUsageAndExit() {
+        print("");
+        print("Usage:");
+        print("  mongosh --quiet --eval 'var _mode=\"indexFilters\"' get-planner-settings.js");
+        print("  mongosh --quiet --eval 'var _mode=\"querySettings\"' get-planner-settings.js");
+        print("");
+        print("Valid _mode values:");
+        print("  indexFilters");
+        print("  querySettings");
+        quit(1);
+    }
+
+    if (_mode !== "indexFilters" && _mode !== "querySettings") {
+        print("Invalid _mode: " + _mode);
+        printUsageAndExit();
+    }
+
+    if (_mode === "indexFilters") {
+        var indexFilterResults = collectIndexFilters();
+
+        printjson({
+            generatedAt: new Date(),
+            host: db.getMongo().host,
+            mode: _mode,
+            summary: {
+                collectionsWithIndexFilters: indexFilterResults.length
+            },
+            results: indexFilterResults
+        });
+        return;
+    }
+
+    var querySettingsResults = collectQuerySettings();
+
+    if (querySettingsResults.error) {
+        printjson({
+            generatedAt: new Date(),
+            host: db.getMongo().host,
+            mode: _mode,
+            error: querySettingsResults.error,
+            results: []
+        });
+        return;
+    }
+
+    printjson({
+        generatedAt: new Date(),
+        host: db.getMongo().host,
+        mode: _mode,
+        summary: {
+            namespacesWithQuerySettings: querySettingsResults.results.length,
+            totalQuerySettingsReturned: querySettingsResults.totalQuerySettingsReturned
+        },
+        results: querySettingsResults.results
+    });
+}());

--- a/migration/toolbox/plannerSettingsChecker/get-planner-settings.js
+++ b/migration/toolbox/plannerSettingsChecker/get-planner-settings.js
@@ -23,11 +23,16 @@
  *     MongoDB 8.0+ and cluster-admin level privileges.
  */
 
+// Mode constants, defined once and reused for defaulting, validation,
+// branching, usage text, and documentation references to prevent drift.
+var MODE_INDEX_FILTERS = "indexFilters";
+var MODE_QUERY_SETTINGS = "querySettings";
+
 // Resolve the mode BEFORE entering the strict-mode IIFE. Assigning to an
 // undeclared identifier inside "use strict" throws a ReferenceError, so the
 // default must be established here.
 if (typeof _mode === "undefined") {
-    var _mode = "indexFilters";
+    var _mode = MODE_INDEX_FILTERS;
 }
 
 (function () {
@@ -51,6 +56,13 @@ if (typeof _mode === "undefined") {
             if (uri) {
                 var withoutScheme = uri.replace(/^mongodb(\+srv)?:\/\//, "");
                 var hostPart = withoutScheme.split("/")[0].split("?")[0];
+
+                // Strip any userinfo ("username:password@") so connection-string
+                // credentials are never echoed into the report.
+                if (hostPart.indexOf("@") !== -1) {
+                    hostPart = hostPart.substring(hostPart.lastIndexOf("@") + 1);
+                }
+
                 if (hostPart) {
                     return hostPart;
                 }
@@ -162,11 +174,30 @@ if (typeof _mode === "undefined") {
                     // The $querySettings output describes the namespace via the
                     // command shape: the database is in "$db" and the collection
                     // is the value of the command name (find/aggregate/etc.).
-                    var collection = rq.find || rq.aggregate || rq.count ||
-                        rq.distinct || rq.update || rq["delete"] || rq.findAndModify;
+                    var commandKeys = [
+                        "find", "aggregate", "count", "distinct",
+                        "update", "delete", "findAndModify"
+                    ];
+                    var commandName = null;
+                    var target = null;
 
-                    if (typeof collection === "string") {
-                        ns = rq["$db"] + "." + collection;
+                    for (var i = 0; i < commandKeys.length; i++) {
+                        if (Object.prototype.hasOwnProperty.call(rq, commandKeys[i])) {
+                            commandName = commandKeys[i];
+                            target = rq[commandName];
+                            break;
+                        }
+                    }
+
+                    if (typeof target === "string") {
+                        ns = rq["$db"] + "." + target;
+                    } else if (commandName) {
+                        // Some commands target a database rather than a named
+                        // collection (for example, a collectionless aggregate
+                        // where "aggregate" is 1). Keep the database actionable
+                        // and note the command type instead of dropping to
+                        // "unknown".
+                        ns = rq["$db"] + ".<" + commandName + ">";
                     }
                 }
             }
@@ -304,21 +335,21 @@ if (typeof _mode === "undefined") {
     function printUsageAndExit() {
         print("");
         print("Usage:");
-        print("  mongosh \"<connection-string>\" --quiet --eval 'var _mode=\"indexFilters\"' get-planner-settings.js");
-        print("  mongosh \"<connection-string>\" --quiet --eval 'var _mode=\"querySettings\"' get-planner-settings.js");
+        print("  mongosh \"<connection-string>\" --quiet --eval 'var _mode=\"" + MODE_INDEX_FILTERS + "\"' get-planner-settings.js");
+        print("  mongosh \"<connection-string>\" --quiet --eval 'var _mode=\"" + MODE_QUERY_SETTINGS + "\"' get-planner-settings.js");
         print("");
         print("Valid _mode values:");
-        print("  indexFilters");
-        print("  querySettings");
+        print("  " + MODE_INDEX_FILTERS);
+        print("  " + MODE_QUERY_SETTINGS);
         quit(1);
     }
 
-    if (_mode !== "indexFilters" && _mode !== "querySettings") {
+    if (_mode !== MODE_INDEX_FILTERS && _mode !== MODE_QUERY_SETTINGS) {
         print("Invalid _mode: " + _mode);
         printUsageAndExit();
     }
 
-    if (_mode === "indexFilters") {
+    if (_mode === MODE_INDEX_FILTERS) {
         var indexFilterResults = collectIndexFilters();
 
         printjson({

--- a/migration/toolbox/plannerSettingsChecker/get-planner-settings.js
+++ b/migration/toolbox/plannerSettingsChecker/get-planner-settings.js
@@ -188,7 +188,20 @@ if (typeof _mode === "undefined") {
     function collectIndexFilters() {
         var allResults = [];
         var errors = [];
-        var dbs = db.getMongo().getDBs();
+        var dbs;
+
+        try {
+            dbs = db.getMongo().getDBs();
+        } catch (e) {
+            // Surface a top-level failure (for example, insufficient privileges
+            // to list databases) instead of aborting the script, so a JSON
+            // report is still produced.
+            errors.push({
+                scope: "listDatabases",
+                error: e.message
+            });
+            return { results: allResults, errors: errors };
+        }
 
         if (!dbs.databases) {
             return { results: allResults, errors: errors };
@@ -291,8 +304,8 @@ if (typeof _mode === "undefined") {
     function printUsageAndExit() {
         print("");
         print("Usage:");
-        print("  mongosh --quiet --eval 'var _mode=\"indexFilters\"' get-planner-settings.js");
-        print("  mongosh --quiet --eval 'var _mode=\"querySettings\"' get-planner-settings.js");
+        print("  mongosh \"<connection-string>\" --quiet --eval 'var _mode=\"indexFilters\"' get-planner-settings.js");
+        print("  mongosh \"<connection-string>\" --quiet --eval 'var _mode=\"querySettings\"' get-planner-settings.js");
         print("");
         print("Valid _mode values:");
         print("  indexFilters");

--- a/migration/toolbox/plannerSettingsChecker/get-planner-settings.js
+++ b/migration/toolbox/plannerSettingsChecker/get-planner-settings.js
@@ -79,7 +79,7 @@ if (typeof _mode === "undefined") {
 
         // Use nameOnly to avoid scanning collection metadata; only the name and
         // type are needed here, both of which are still returned in this mode.
-        database.getCollectionInfos({ "type": "collection" }, {nameOnly:true}).forEach(function (collectionInfo) {
+        database.getCollectionInfos({ "type": "collection" }, { "nameOnly": true }).forEach(function (collectionInfo) {
             var name = collectionInfo.name;
 
             if (name.indexOf("system.") === 0) {

--- a/migration/toolbox/plannerSettingsChecker/get-planner-settings.js
+++ b/migration/toolbox/plannerSettingsChecker/get-planner-settings.js
@@ -25,18 +25,49 @@
 
 // Resolve the mode BEFORE entering the strict-mode IIFE. Assigning to an
 // undeclared identifier inside "use strict" throws a ReferenceError, so the
-// default must be established here on the global object.
+// default must be established here.
 if (typeof _mode === "undefined") {
-    globalThis._mode = "indexFilters";
+    var _mode = "indexFilters";
 }
 
 (function () {
     "use strict";
 
+    function getHostInfo() {
+        // db.getMongo().host is not populated in mongosh, so fall back to the
+        // host reported by hello() (set on replica sets/sharded clusters) and
+        // then to the host portion of the connection URI for standalones.
+        try {
+            var me = db.hello().me;
+            if (me) {
+                return me;
+            }
+        } catch (e) {
+            // ignore and fall through to the URI-based resolution
+        }
+
+        try {
+            var uri = db.getMongo()._uri;
+            if (uri) {
+                var withoutScheme = uri.replace(/^mongodb(\+srv)?:\/\//, "");
+                var hostPart = withoutScheme.split("/")[0].split("?")[0];
+                if (hostPart) {
+                    return hostPart;
+                }
+            }
+        } catch (e) {
+            // ignore and fall through to the default
+        }
+
+        return "unknown";
+    }
+
     function getCollectionNames(database) {
         var collectionNames = [];
 
-        database.getCollectionInfos({ "type": "collection" }).forEach(function (collectionInfo) {
+        // Use nameOnly to avoid scanning collection metadata; only the name and
+        // type are needed here, both of which are still returned in this mode.
+        database.getCollectionInfos({ "type": "collection" }, {nameOnly:true}).forEach(function (collectionInfo) {
             var name = collectionInfo.name;
 
             if (name.indexOf("system.") === 0) {
@@ -97,22 +128,14 @@ if (typeof _mode === "undefined") {
         };
 
         try {
-            var cmd = db.adminCommand({
-                aggregate: 1,
-                pipeline: [
-                    { $querySettings: {} }
-                ],
-                cursor: {}
-            });
+            var admin = db.getSiblingDB("admin");
 
-            if (!cmd.ok) {
-                res.error = cmd;
-                return res;
-            }
-
-            if (cmd.cursor && cmd.cursor.firstBatch) {
-                res.querySettings = cmd.cursor.firstBatch;
-            }
+            // Use the aggregate() helper with toArray() so the driver iterates
+            // the full cursor; results that span multiple batches are not
+            // silently truncated to just the first batch.
+            res.querySettings = admin.aggregate([
+                { $querySettings: {} }
+            ]).toArray();
 
             res.ok = true;
         } catch (e) {
@@ -130,8 +153,22 @@ if (typeof _mode === "undefined") {
 
             if (entry.namespace) {
                 ns = entry.namespace;
-            } else if (entry.representativeQuery && entry.representativeQuery.namespace) {
-                ns = entry.representativeQuery.namespace;
+            } else if (entry.representativeQuery) {
+                var rq = entry.representativeQuery;
+
+                if (rq.namespace) {
+                    ns = rq.namespace;
+                } else if (rq["$db"]) {
+                    // The $querySettings output describes the namespace via the
+                    // command shape: the database is in "$db" and the collection
+                    // is the value of the command name (find/aggregate/etc.).
+                    var collection = rq.find || rq.aggregate || rq.count ||
+                        rq.distinct || rq.update || rq["delete"] || rq.findAndModify;
+
+                    if (typeof collection === "string") {
+                        ns = rq["$db"] + "." + collection;
+                    }
+                }
             }
 
             if (!ns) {
@@ -150,10 +187,11 @@ if (typeof _mode === "undefined") {
 
     function collectIndexFilters() {
         var allResults = [];
+        var errors = [];
         var dbs = db.getMongo().getDBs();
 
         if (!dbs.databases) {
-            return allResults;
+            return { results: allResults, errors: errors };
         }
 
         dbs.databases.forEach(function (dbInfo) {
@@ -163,11 +201,31 @@ if (typeof _mode === "undefined") {
             try {
                 collections = getCollectionNames(database);
             } catch (e) {
+                // Surface database-level failures (for example, due to
+                // restricted privileges) rather than silently skipping them.
+                errors.push({
+                    db: dbInfo.name,
+                    scope: "database",
+                    error: e.message
+                });
                 return;
             }
 
             collections.forEach(function (collectionName) {
                 var result = getCollectionIndexFilters(database, collectionName);
+
+                if (result.error) {
+                    // Surface collection-level failures so they are visible in
+                    // the report instead of being filtered out.
+                    errors.push({
+                        db: result.db,
+                        collection: result.collection,
+                        namespace: result.namespace,
+                        scope: "collection",
+                        error: result.error
+                    });
+                    return;
+                }
 
                 if (result.hasIndexFilters) {
                     allResults.push(result);
@@ -175,7 +233,7 @@ if (typeof _mode === "undefined") {
             });
         });
 
-        return allResults;
+        return { results: allResults, errors: errors };
     }
 
     function collectQuerySettings() {
@@ -252,12 +310,14 @@ if (typeof _mode === "undefined") {
 
         printjson({
             generatedAt: new Date(),
-            host: db.getMongo().host,
+            host: getHostInfo(),
             mode: _mode,
             summary: {
-                collectionsWithIndexFilters: indexFilterResults.length
+                collectionsWithIndexFilters: indexFilterResults.results.length,
+                errorCount: indexFilterResults.errors.length
             },
-            results: indexFilterResults
+            results: indexFilterResults.results,
+            errors: indexFilterResults.errors
         });
         return;
     }
@@ -267,7 +327,7 @@ if (typeof _mode === "undefined") {
     if (querySettingsResults.error) {
         printjson({
             generatedAt: new Date(),
-            host: db.getMongo().host,
+            host: getHostInfo(),
             mode: _mode,
             error: querySettingsResults.error,
             results: []
@@ -277,7 +337,7 @@ if (typeof _mode === "undefined") {
 
     printjson({
         generatedAt: new Date(),
-        host: db.getMongo().host,
+        host: getHostInfo(),
         mode: _mode,
         summary: {
             namespacesWithQuerySettings: querySettingsResults.results.length,


### PR DESCRIPTION
Jira Ticket Reference [MIGRATION-885](https://jira.mongodb.org/browse/MIGRATION-885)

Adding Planner Settings Checker tool to migration toolbox. This script is intended to identify any existing index filters or query settings on the source cluster that may impact cluster performance on the destination after migration.