### PR TITLE
MF-TASK-MIGRATION-754: add unique index format validation

### DIFF
--- a/migration/toolbox/README.md
+++ b/migration/toolbox/README.md
@@ -34,6 +34,10 @@ Audits query planner customizations across all databases and collections, report
 
 Scans recent change-stream write activity and identifies documents that are hot enough to plausibly explain high applier spread disparity. The script applies a spread-disparity threshold plus per-document and total-window changes-per-second gates to reduce low-traffic false positives. For full documentation and examples, see [hotDocSpreadCheck README](hotDocSpreadCheck/README.md).
 
+## [Index Format Validation](indexFormatValidation)
+
+Checks unique non-`_id_` indexes across all non-system databases for WiredTiger index format versions below 13, which may indicate indexes created on MongoDB versions earlier than 4.2 and needing review before migration. For full documentation and examples, see [indexFormatValidation README](indexFormatValidation/README.md).
+
 ### License
 
 [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/migration/toolbox/indexFormatValidation/README.md
+++ b/migration/toolbox/indexFormatValidation/README.md
@@ -31,7 +31,7 @@ Exit codes:
 The script reads directly from the connected deployment using:
 
 - `listDatabases` with `nameOnly: true` to find databases
-- `getCollectionInfos({}, true, true)` to find collections
+- `getCollectionInfos({}, nameOnly, authorizedCollections)` to find collections
 - `getIndexes()` to find unique index specs
 - `collStats` with `indexDetails: true` to read WiredTiger index metadata
 

--- a/migration/toolbox/indexFormatValidation/README.md
+++ b/migration/toolbox/indexFormatValidation/README.md
@@ -31,7 +31,7 @@ Exit codes:
 The script reads directly from the connected deployment using:
 
 - `listDatabases` with `nameOnly: true` to find databases
-- `getCollectionInfos({}, nameOnly, authorizedCollections)` to find collections
+- `getCollectionInfos({}, { nameOnly: true, authorizedCollections: true })` to find collections
 - `getIndexes()` to find unique index specs
 - `collStats` with `indexDetails: true` to read WiredTiger index metadata
 

--- a/migration/toolbox/indexFormatValidation/README.md
+++ b/migration/toolbox/indexFormatValidation/README.md
@@ -6,6 +6,8 @@ The checker assumes unique indexes with a WiredTiger index `formatVersion` below
 
 ## Usage
 
+Requires `mongosh` and MongoDB 4.0 or newer.
+
 ```bash
 mongosh "<connection-string>" indexFormatValidation.js
 ```
@@ -28,12 +30,14 @@ Exit codes:
 
 The script reads directly from the connected deployment using:
 
-- `listDatabases` to find databases
-- `getCollectionInfos({ type: "collection" }, { nameOnly: true })` to find collections
+- `listDatabases` with `nameOnly: true` to find databases
+- `getCollectionInfos({}, true, true)` to find collections
 - `getIndexes()` to find unique index specs
 - `collStats` with `indexDetails: true` to read WiredTiger index metadata
 
-System databases `admin`, `config`, and `local` are skipped. Collections whose names start with `system.` are also skipped.
+System databases `admin`, `config`, and `local` are skipped, along with views, timeseries collections (which cannot have unique indexes), and collections whose names start with `system.`.
+
+Collections are listed with `authorizedCollections: true`, so a user without cluster-wide `listCollections` privileges still gets a scan across the collections they are authorized to read. That mode restricts server-side filters to `name`, so the collection type is filtered client-side.
 
 The script checks `formatVersion` or `metadata.formatVersion` from the `collStats` index details. Plain `db.collection.getIndexes()` output is not sufficient by itself because its `v` field is the index spec version, not the WiredTiger `formatVersion` checked by this script.
 
@@ -67,9 +71,11 @@ Each entry in `errors` includes:
 - `collection` and `namespace` (only for `collection` scope)
 - `error`
 
+For a failed command, `error` reads `<command> failed: <errmsg> (<codeName or code>)` using the fields the server returned. A `listDatabases` call that succeeds but returns an unexpected payload is reported separately as `listDatabases returned an unexpected response shape`.
+
 Collections without unique non-`_id_` indexes are skipped before `collStats` runs, so permission errors on those namespaces are not reported.
 
-When a suspicious index is found, the `advisory` field is included with guidance to run `validate` as a secondary check. The old unique-index-format warning from `validate` is available starting in MongoDB 6.0; on older versions, `validate` may return no warning even when risk remains. `validate` is resource consuming and should be used with caution.
+When a suspicious index is found, the `advisory` field is included with guidance to run `validate` as a secondary check. The old unique-index-format warning from `validate` is available starting in MongoDB 6.0; on older versions, `validate` may return no warning even when the risk remains. Because `validate` obtains an exclusive lock on the collection, it blocks reads and writes until it completes; when run on a secondary, it may block other operations on that secondary. It is resource-intensive, so run it with caution.
 
 The `suggestedValidateCommand` field includes a ready-to-run sample in this format:
 

--- a/migration/toolbox/indexFormatValidation/README.md
+++ b/migration/toolbox/indexFormatValidation/README.md
@@ -56,6 +56,8 @@ Each finding includes:
 
 For sharded collections, `formatVersions` contains one entry per shard that reported a parseable version, and `unknownLocations` lists the shards that did not.
 
+For standalone nodes and replica sets, `formatVersions.default` contains the reported version. If the version cannot be determined, `unknownLocations` contains `default`.
+
 Statuses:
 
 - `POTENTIALLY_PRE_42_UNIQUE_INDEX`: unique index has `formatVersion` lower than `13`
@@ -73,7 +75,7 @@ Each entry in `errors` includes:
 
 For a failed command, `error` reads `<command> failed: <errmsg> (<codeName or code>)` using the fields the server returned. A `listDatabases` call that succeeds but returns an unexpected payload is reported separately as `listDatabases returned an unexpected response shape`.
 
-Collections without unique non-`_id_` indexes are skipped before `collStats` runs, so permission errors on those namespaces are not reported.
+The script calls `getIndexes()` for every scanned collection. If a collection has no unique non-`_id_` indexes, `collStats` is not run for that collection, so `collStats` permission errors on those namespaces are not reported.
 
 When a suspicious index is found, the `advisory` field is included with guidance to run `validate` as a secondary check. The old unique-index-format warning from `validate` is available starting in MongoDB 6.0; on older versions, `validate` may return no warning even when the risk remains. Because `validate` obtains an exclusive lock on the collection, it blocks reads and writes until it completes; when run on a secondary, it may block other operations on that secondary. It is resource-intensive, so run it with caution.
 

--- a/migration/toolbox/indexFormatValidation/README.md
+++ b/migration/toolbox/indexFormatValidation/README.md
@@ -1,0 +1,64 @@
+# Index Format Validation
+
+Checks unique non-`_id_` indexes across all non-system databases for legacy storage engine index format versions that may cause migration issues.
+
+The checker assumes unique indexes with a WiredTiger index `formatVersion` below `13` were created on MongoDB versions earlier than 4.2, or otherwise still use a legacy on-disk format. Indexes with `formatVersion` `13` or newer are reported as valid.
+
+## Usage
+
+```bash
+mongosh "<connection-string>" indexFormatValidation.js
+```
+
+By default, the script checks all collections in all databases except `admin`, `config`, and `local`. It prints only indexes that need review.
+
+To include valid unique indexes in the output, set `_showAll=true`:
+
+```bash
+mongosh "<connection-string>" --eval 'var _showAll=true' indexFormatValidation.js
+```
+
+Exit codes:
+
+- `0`: no suspicious indexes found and no runtime errors
+- `1`: one or more suspicious indexes found
+- `2`: runtime or permission errors were encountered while scanning
+
+## Source Data
+
+The script reads directly from the connected deployment using:
+
+- `listDatabases` to find databases
+- `getCollectionInfos({ type: "collection" }, { nameOnly: true })` to find collections
+- `getIndexes()` to find unique index specs
+- `collStats` with `indexDetails: true` to read WiredTiger index metadata
+
+System databases `admin`, `config`, and `local` are skipped. Collections whose names start with `system.` are also skipped.
+
+The script checks `formatVersion` or `metadata.formatVersion` from the `collStats` index details. Plain `db.collection.getIndexes()` output is not sufficient by itself because its `v` field is the index spec version, not the WiredTiger `formatVersion` checked by this script.
+
+## Output
+
+Each finding includes:
+
+- `namespace`
+- `indexName`
+- `key`
+- `formatVersions`
+- `status`
+- `suggestedValidateCommand` (only for suspicious findings)
+- `advisory` (only for suspicious findings)
+
+For sharded collections, `formatVersions` may contain one entry per shard.
+
+Statuses:
+
+- `POTENTIALLY_PRE_42_UNIQUE_INDEX`: unique index has `formatVersion` lower than `13`
+- `UNKNOWN_FORMAT_VERSION`: unique index is missing a parseable `formatVersion`
+- `VALID`: unique index has `formatVersion` `13` or newer, shown only when `_showAll=true`
+
+When a suspicious index is found, the `advisory` field is included with guidance to run `validate` as a secondary check. The old unique-index-format warning from `validate` is available starting in MongoDB 6.0; on older versions, `validate` may return no warning even when risk remains. `validate` is resource consuming and should be used with caution.
+
+The `suggestedValidateCommand` field includes a ready-to-run sample in this format:
+
+`db.getSiblingDB('database_name').getCollection('collection_name').validate({full:true}).warnings`

--- a/migration/toolbox/indexFormatValidation/README.md
+++ b/migration/toolbox/indexFormatValidation/README.md
@@ -45,17 +45,29 @@ Each finding includes:
 - `indexName`
 - `key`
 - `formatVersions`
+- `unknownLocations`
 - `status`
 - `suggestedValidateCommand` (only for suspicious findings)
 - `advisory` (only for suspicious findings)
 
-For sharded collections, `formatVersions` may contain one entry per shard.
+For sharded collections, `formatVersions` contains one entry per shard that reported a parseable version, and `unknownLocations` lists the shards that did not.
 
 Statuses:
 
 - `POTENTIALLY_PRE_42_UNIQUE_INDEX`: unique index has `formatVersion` lower than `13`
-- `UNKNOWN_FORMAT_VERSION`: unique index is missing a parseable `formatVersion`
-- `VALID`: unique index has `formatVersion` `13` or newer, shown only when `_showAll=true`
+- `UNKNOWN_FORMAT_VERSION`: unique index is missing a parseable `formatVersion` in at least one location
+- `VALID`: unique index has `formatVersion` `13` or newer in every location, shown only when `_showAll=true`
+
+On sharded clusters, `UNKNOWN_FORMAT_VERSION` for a subset of shards is often benign: the index may still be building, or the shard may report no index details. Use `unknownLocations` to identify which shards to re-check.
+
+Each entry in `errors` includes:
+
+- `scope`: `cluster`, `database`, or `collection`
+- `db` (not present for `cluster` scope)
+- `collection` and `namespace` (only for `collection` scope)
+- `error`
+
+Collections without unique non-`_id_` indexes are skipped before `collStats` runs, so permission errors on those namespaces are not reported.
 
 When a suspicious index is found, the `advisory` field is included with guidance to run `validate` as a secondary check. The old unique-index-format warning from `validate` is available starting in MongoDB 6.0; on older versions, `validate` may return no warning even when risk remains. `validate` is resource consuming and should be used with caution.
 

--- a/migration/toolbox/indexFormatValidation/indexFormatValidation.js
+++ b/migration/toolbox/indexFormatValidation/indexFormatValidation.js
@@ -69,9 +69,10 @@ if (typeof _showAll === "undefined") {
 
     function getCollectionNames(database) {
         var collectionNames = [];
+        var nameOnly = true;
+        var authorizedCollections = true;
 
-        // Positional args: filter, nameOnly, authorizedCollections. The last one lets scoped users list what they can read.
-        database.getCollectionInfos({}, true, true).forEach(function (collectionInfo) {
+        database.getCollectionInfos({}, nameOnly, authorizedCollections).forEach(function (collectionInfo) {
             // listCollections restricts filters to "name" for unprivileged users, so filter by type here.
             if (collectionInfo.type && collectionInfo.type !== "collection") {
                 return;

--- a/migration/toolbox/indexFormatValidation/indexFormatValidation.js
+++ b/migration/toolbox/indexFormatValidation/indexFormatValidation.js
@@ -69,10 +69,11 @@ if (typeof _showAll === "undefined") {
 
     function getCollectionNames(database) {
         var collectionNames = [];
-        var nameOnly = true;
-        var authorizedCollections = true;
 
-        database.getCollectionInfos({}, nameOnly, authorizedCollections).forEach(function (collectionInfo) {
+        database.getCollectionInfos({}, {
+            nameOnly: true,
+            authorizedCollections: true
+        }).forEach(function (collectionInfo) {
             // listCollections restricts filters to "name" for unprivileged users, so filter by type here.
             if (collectionInfo.type && collectionInfo.type !== "collection") {
                 return;

--- a/migration/toolbox/indexFormatValidation/indexFormatValidation.js
+++ b/migration/toolbox/indexFormatValidation/indexFormatValidation.js
@@ -8,8 +8,8 @@ var PROBLEM_STATUSES = [
 ];
 var EXIT_CODE_WITH_FINDINGS = 1;
 var EXIT_CODE_WITH_ERRORS = 2;
-var LEGACY_INDEX_ADVISORY = "This index may have been created before MongoDB 4.2 and as a result may still use a legacy unique-index key format. Use validate as a secondary check, but note that the old-format warning is available starting in MongoDB 6.0. On versions below 6.0, validate may return no warning even when risk remains. Validate is resource consuming, so run it with caution.";
-var UNKNOWN_VERSION_ADVISORY = "Unable to determine the index format version from collStats index details. Use validate as a secondary check, but note that the old-format warning is available starting in MongoDB 6.0. On versions below 6.0, validate may return no warning even when risk remains. Validate is resource consuming, so run it with caution.";
+var LEGACY_INDEX_ADVISORY = "This index may have been created before MongoDB 4.2 and may still use a legacy unique-index key format. Use `validate` as a secondary check, but note that the old-format warning is available starting in MongoDB 6.0. On versions below 6.0, `validate` may return no warning even when the risk remains. Because `validate` obtains an exclusive lock on the collection, it blocks reads and writes until it completes; when run on a secondary, it may block other operations on that secondary. It is resource-intensive, so run it with caution.";
+var UNKNOWN_VERSION_ADVISORY = "Unable to determine the index format version from collStats index details. Use `validate` as a secondary check, but note that the old-format warning is available starting in MongoDB 6.0. On versions below 6.0, `validate` may return no warning even when the risk remains. Because `validate` obtains an exclusive lock on the collection, it blocks reads and writes until it completes; when run on a secondary, it may block other operations on that secondary. It is resource-intensive, so run it with caution.";
 
 if (typeof _showAll === "undefined") {
     var _showAll = false;
@@ -22,9 +22,30 @@ if (typeof _showAll === "undefined") {
         return PROBLEM_STATUSES.indexOf(status) !== -1;
     }
 
+    function formatCommandError(label, response) {
+        var detail = response && (response.codeName || response.code);
+
+        return label + " failed: " + ((response && response.errmsg) || "unknown error") +
+            (detail ? " (" + detail + ")" : "");
+    }
+
     function getFormatVersionFromValue(value) {
+        // Dates coerce to an epoch-millisecond integer, so reject them before any numeric conversion.
+        if (Object.prototype.toString.call(value) === "[object Date]") {
+            return null;
+        }
+
+        // Handles both Extended JSON wrappers and mongosh BSON numeric types.
         if (value && typeof value === "object") {
-            value = value.$numberInt || value.$numberLong || value.$numberDouble;
+            if (value.$numberInt !== undefined) {
+                value = value.$numberInt;
+            } else if (value.$numberLong !== undefined) {
+                value = value.$numberLong;
+            } else if (value.$numberDouble !== undefined) {
+                value = value.$numberDouble;
+            } else if (typeof value.toNumber === "function") {
+                value = value.toNumber();
+            }
         }
 
         var version = Number(value);
@@ -39,7 +60,7 @@ if (typeof _showAll === "undefined") {
 
         var value = indexDetail.formatVersion;
 
-        if (value === undefined && indexDetail.metadata) {
+        if ((value === undefined || value === null) && indexDetail.metadata) {
             value = indexDetail.metadata.formatVersion;
         }
 
@@ -49,7 +70,13 @@ if (typeof _showAll === "undefined") {
     function getCollectionNames(database) {
         var collectionNames = [];
 
-        database.getCollectionInfos({ type: "collection" }, { nameOnly: true }).forEach(function (collectionInfo) {
+        // Positional args: filter, nameOnly, authorizedCollections. The last one lets scoped users list what they can read.
+        database.getCollectionInfos({}, true, true).forEach(function (collectionInfo) {
+            // listCollections restricts filters to "name" for unprivileged users, so filter by type here.
+            if (collectionInfo.type && collectionInfo.type !== "collection") {
+                return;
+            }
+
             if (collectionInfo.name.indexOf("system.") === 0) {
                 return;
             }
@@ -66,8 +93,8 @@ if (typeof _showAll === "undefined") {
             indexDetails: true
         });
 
-        if (!stats.ok) {
-            throw new Error(EJSON.stringify(stats));
+        if (!stats || !stats.ok) {
+            throw new Error(formatCommandError("collStats", stats));
         }
 
         return stats;
@@ -78,7 +105,7 @@ if (typeof _showAll === "undefined") {
             return null;
         }
 
-        if (indexDetails[indexName]) {
+        if (Object.prototype.hasOwnProperty.call(indexDetails, indexName) && indexDetails[indexName]) {
             return indexDetails[indexName];
         }
 
@@ -209,10 +236,14 @@ if (typeof _showAll === "undefined") {
     }
 
     function getUserDatabases() {
-        var response = db.adminCommand("listDatabases");
+        var response = db.adminCommand({ listDatabases: 1, nameOnly: true });
 
-        if (!response || !response.ok || !Array.isArray(response.databases)) {
-            throw new Error("listDatabases failed: " + EJSON.stringify(response));
+        if (!response || !response.ok) {
+            throw new Error(formatCommandError("listDatabases", response));
+        }
+
+        if (!Array.isArray(response.databases)) {
+            throw new Error("listDatabases returned an unexpected response shape");
         }
 
         return response.databases.filter(function (databaseInfo) {

--- a/migration/toolbox/indexFormatValidation/indexFormatValidation.js
+++ b/migration/toolbox/indexFormatValidation/indexFormatValidation.js
@@ -8,8 +8,9 @@ var PROBLEM_STATUSES = [
 ];
 var EXIT_CODE_WITH_FINDINGS = 1;
 var EXIT_CODE_WITH_ERRORS = 2;
-var LEGACY_INDEX_ADVISORY = "This index may have been created before MongoDB 4.2 and may still use a legacy unique-index key format. Use `validate` as a secondary check, but note that the old-format warning is available starting in MongoDB 6.0. On versions below 6.0, `validate` may return no warning even when the risk remains. Because `validate` obtains an exclusive lock on the collection, it blocks reads and writes until it completes; when run on a secondary, it may block other operations on that secondary. It is resource-intensive, so run it with caution.";
-var UNKNOWN_VERSION_ADVISORY = "Unable to determine the index format version from collStats index details. Use `validate` as a secondary check, but note that the old-format warning is available starting in MongoDB 6.0. On versions below 6.0, `validate` may return no warning even when the risk remains. Because `validate` obtains an exclusive lock on the collection, it blocks reads and writes until it completes; when run on a secondary, it may block other operations on that secondary. It is resource-intensive, so run it with caution.";
+var VALIDATE_ADVISORY = "Use `validate` as a secondary check, but note that the old-format warning is available starting in MongoDB 6.0. On versions below 6.0, `validate` may return no warning even when the risk remains. Because `validate` obtains an exclusive lock on the collection, it blocks reads and writes until it completes; when run on a secondary, it may block other operations on that secondary. It is resource-intensive, so run it with caution.";
+var LEGACY_INDEX_ADVISORY = "This index may have been created before MongoDB 4.2 and may still use a legacy unique-index key format. " + VALIDATE_ADVISORY;
+var UNKNOWN_VERSION_ADVISORY = "Unable to determine the index format version from collStats index details. " + VALIDATE_ADVISORY;
 
 if (typeof _showAll === "undefined") {
     var _showAll = false;

--- a/migration/toolbox/indexFormatValidation/indexFormatValidation.js
+++ b/migration/toolbox/indexFormatValidation/indexFormatValidation.js
@@ -1,0 +1,287 @@
+/* global db, print, quit, EJSON, _showAll */
+
+var MIN_SAFE_FORMAT_VERSION = 13;
+var EXCLUDED_DATABASES = ["admin", "config", "local"];
+var PROBLEM_STATUSES = [
+    "POTENTIALLY_PRE_42_UNIQUE_INDEX",
+    "UNKNOWN_FORMAT_VERSION"
+];
+var EXIT_CODE_WITH_FINDINGS = 1;
+var EXIT_CODE_WITH_ERRORS = 2;
+var LEGACY_INDEX_ADVISORY = "This index may have been created before MongoDB 4.2 and as a result may still use a legacy unique-index key format. Use validate as a secondary check, but note that the old-format warning is available starting in MongoDB 6.0. On versions below 6.0, validate may return no warning even when risk remains. Validate is resource consuming, so run it with caution.";
+var UNKNOWN_VERSION_ADVISORY = "Unable to determine the index format version from collStats index details. Use validate as a secondary check, but note that the old-format warning is available starting in MongoDB 6.0. On versions below 6.0, validate may return no warning even when risk remains. Validate is resource consuming, so run it with caution.";
+
+if (typeof _showAll === "undefined") {
+    var _showAll = false;
+}
+
+(function () {
+    "use strict";
+
+    function isProblemStatus(status) {
+        return PROBLEM_STATUSES.indexOf(status) !== -1;
+    }
+
+    function getFormatVersionFromValue(value) {
+        if (value && typeof value === "object") {
+            value = value.$numberInt || value.$numberLong || value.$numberDouble;
+        }
+
+        var version = Number(value);
+
+        return Number.isInteger(version) ? version : null;
+    }
+
+    function getFormatVersion(indexDetail) {
+        if (!indexDetail) {
+            return null;
+        }
+
+        var value = indexDetail.formatVersion;
+
+        if (value === undefined && indexDetail.metadata) {
+            value = indexDetail.metadata.formatVersion;
+        }
+
+        return getFormatVersionFromValue(value);
+    }
+
+    function getCollectionNames(database) {
+        var collectionNames = [];
+
+        database.getCollectionInfos({ type: "collection" }, { nameOnly: true }).forEach(function (collectionInfo) {
+            if (collectionInfo.name.indexOf("system.") === 0) {
+                return;
+            }
+
+            collectionNames.push(collectionInfo.name);
+        });
+
+        return collectionNames;
+    }
+
+    function getIndexDetails(database, collectionName) {
+        var stats = database.runCommand({
+            collStats: collectionName,
+            indexDetails: true
+        });
+
+        if (!stats.ok) {
+            throw new Error(EJSON.stringify(stats));
+        }
+
+        return stats;
+    }
+
+    function findIndexDetail(indexDetails, indexName) {
+        if (!indexDetails) {
+            return null;
+        }
+
+        if (indexDetails[indexName]) {
+            return indexDetails[indexName];
+        }
+
+        for (var detailName in indexDetails) {
+            if (Object.prototype.hasOwnProperty.call(indexDetails, detailName)) {
+                var detail = indexDetails[detailName];
+
+                if (detail && detail.metadata && detail.metadata.name === indexName) {
+                    return detail;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    function getFormatVersions(stats, indexName) {
+        var versions = {};
+
+        var topLevelVersion = getFormatVersion(findIndexDetail(stats.indexDetails, indexName));
+        if (topLevelVersion !== null) {
+            versions.default = topLevelVersion;
+        }
+
+        if (stats.shards) {
+            for (var shardName in stats.shards) {
+                if (Object.prototype.hasOwnProperty.call(stats.shards, shardName)) {
+                    var shardStats = stats.shards[shardName];
+                    var shardVersion = getFormatVersion(findIndexDetail(shardStats.indexDetails, indexName));
+
+                    if (shardVersion !== null) {
+                        versions[shardName] = shardVersion;
+                    }
+                }
+            }
+        }
+
+        return versions;
+    }
+
+    function classifyFormatVersions(formatVersions) {
+        var versionValues = Object.keys(formatVersions).map(function (location) {
+            return formatVersions[location];
+        });
+
+        if (versionValues.length === 0) {
+            return "UNKNOWN_FORMAT_VERSION";
+        }
+
+        var hasLegacyVersion = versionValues.some(function (version) {
+            return version < MIN_SAFE_FORMAT_VERSION;
+        });
+
+        return hasLegacyVersion ? "POTENTIALLY_PRE_42_UNIQUE_INDEX" : "VALID";
+    }
+
+    function getAdvisory(status) {
+        if (status === "POTENTIALLY_PRE_42_UNIQUE_INDEX") {
+            return LEGACY_INDEX_ADVISORY;
+        }
+
+        if (status === "UNKNOWN_FORMAT_VERSION") {
+            return UNKNOWN_VERSION_ADVISORY;
+        }
+
+        return null;
+    }
+
+    function buildSuggestedValidateCommand(databaseName, collectionName) {
+        function escapeSingleQuotedLiteral(value) {
+            return String(value).replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+        }
+
+        var safeDatabaseName = escapeSingleQuotedLiteral(databaseName);
+        var safeCollectionName = escapeSingleQuotedLiteral(collectionName);
+
+        return "db.getSiblingDB('" + safeDatabaseName + "').getCollection('" + safeCollectionName + "').validate({full:true}).warnings";
+    }
+
+    function validateIndex(databaseName, collectionName, indexSpec, stats) {
+        if (indexSpec.name === "_id_") {
+            return null;
+        }
+
+        if (indexSpec.unique !== true) {
+            return null;
+        }
+
+        var formatVersions = getFormatVersions(stats, indexSpec.name);
+        var status = classifyFormatVersions(formatVersions);
+
+        var advisory = getAdvisory(status);
+        var result = {
+            db: databaseName,
+            collection: collectionName,
+            namespace: databaseName + "." + collectionName,
+            indexName: indexSpec.name || "<unnamed>",
+            key: indexSpec.key || "<unknown key pattern>",
+            formatVersions: Object.keys(formatVersions).length ? formatVersions : "unknown",
+            status: status
+        };
+
+        if (advisory) {
+            result.advisory = advisory;
+            result.suggestedValidateCommand = buildSuggestedValidateCommand(databaseName, collectionName);
+        }
+
+        return result;
+    }
+
+    function getUserDatabases() {
+        var response = db.adminCommand("listDatabases");
+
+        if (!response || !response.ok || !Array.isArray(response.databases)) {
+            throw new Error("listDatabases failed: " + EJSON.stringify(response));
+        }
+
+        return response.databases.filter(function (databaseInfo) {
+            return EXCLUDED_DATABASES.indexOf(databaseInfo.name) === -1;
+        });
+    }
+
+    function collectFindings() {
+        var results = [];
+        var errors = [];
+        var databases = getUserDatabases();
+
+        databases.forEach(function (databaseInfo) {
+            var currentDb = db.getSiblingDB(databaseInfo.name);
+
+            getCollectionNames(currentDb).forEach(function (collectionName) {
+                var currentCollection = currentDb.getCollection(collectionName);
+                var stats;
+
+                try {
+                    stats = getIndexDetails(currentDb, collectionName);
+                } catch (e) {
+                    errors.push({
+                        db: databaseInfo.name,
+                        collection: collectionName,
+                        namespace: databaseInfo.name + "." + collectionName,
+                        error: e.message
+                    });
+                    return;
+                }
+
+                currentCollection.getIndexes().forEach(function (indexSpec) {
+                    var result = validateIndex(databaseInfo.name, collectionName, indexSpec, stats);
+
+                    if (result) {
+                        results.push(result);
+                    }
+                });
+            });
+        });
+
+        return {
+            results: results,
+            errors: errors
+        };
+    }
+
+    var audit;
+
+    try {
+        audit = collectFindings();
+    } catch (e) {
+        audit = {
+            results: [],
+            errors: [
+                {
+                    scope: "cluster",
+                    error: e.message
+                }
+            ]
+        };
+    }
+
+    var findings = _showAll
+        ? audit.results
+        : audit.results.filter(function (result) {
+            return isProblemStatus(result.status);
+        });
+    var output = {
+        checkedAt: new Date().toISOString(),
+        minSafeFormatVersion: MIN_SAFE_FORMAT_VERSION,
+        excludedDatabases: EXCLUDED_DATABASES,
+        showAll: _showAll,
+        totalUniqueIndexesChecked: audit.results.length,
+        findings: findings,
+        errors: audit.errors
+    };
+    var hasProblems = audit.results.some(function (result) {
+        return isProblemStatus(result.status);
+    });
+
+    print(EJSON.stringify(output, null, 2));
+
+    if (audit.errors.length) {
+        quit(EXIT_CODE_WITH_ERRORS);
+    }
+
+    if (hasProblems) {
+        quit(EXIT_CODE_WITH_FINDINGS);
+    }
+}());

--- a/migration/toolbox/indexFormatValidation/indexFormatValidation.js
+++ b/migration/toolbox/indexFormatValidation/indexFormatValidation.js
@@ -97,11 +97,7 @@ if (typeof _showAll === "undefined") {
 
     function getFormatVersions(stats, indexName) {
         var versions = {};
-
-        var topLevelVersion = getFormatVersion(findIndexDetail(stats.indexDetails, indexName));
-        if (topLevelVersion !== null) {
-            versions.default = topLevelVersion;
-        }
+        var unknownLocations = [];
 
         if (stats.shards) {
             for (var shardName in stats.shards) {
@@ -109,30 +105,48 @@ if (typeof _showAll === "undefined") {
                     var shardStats = stats.shards[shardName];
                     var shardVersion = getFormatVersion(findIndexDetail(shardStats.indexDetails, indexName));
 
-                    if (shardVersion !== null) {
+                    if (shardVersion === null) {
+                        unknownLocations.push(shardName);
+                    } else {
                         versions[shardName] = shardVersion;
                     }
                 }
             }
+        } else {
+            var topLevelVersion = getFormatVersion(findIndexDetail(stats.indexDetails, indexName));
+
+            if (topLevelVersion === null) {
+                unknownLocations.push("default");
+            } else {
+                versions.default = topLevelVersion;
+            }
         }
 
-        return versions;
+        return {
+            versions: versions,
+            unknownLocations: unknownLocations
+        };
     }
 
-    function classifyFormatVersions(formatVersions) {
-        var versionValues = Object.keys(formatVersions).map(function (location) {
-            return formatVersions[location];
+    function classifyFormatVersions(versions, unknownLocations) {
+        var versionValues = Object.keys(versions).map(function (location) {
+            return versions[location];
         });
 
-        if (versionValues.length === 0) {
+        var hasLegacyVersion = versionValues.some(function (version) {
+            return typeof version === "number" && version < MIN_SAFE_FORMAT_VERSION;
+        });
+
+        // A confirmed legacy location outranks an unknown one: the advisory is the same either way.
+        if (hasLegacyVersion) {
+            return "POTENTIALLY_PRE_42_UNIQUE_INDEX";
+        }
+
+        if (unknownLocations.length || versionValues.length === 0) {
             return "UNKNOWN_FORMAT_VERSION";
         }
 
-        var hasLegacyVersion = versionValues.some(function (version) {
-            return version < MIN_SAFE_FORMAT_VERSION;
-        });
-
-        return hasLegacyVersion ? "POTENTIALLY_PRE_42_UNIQUE_INDEX" : "VALID";
+        return "VALID";
     }
 
     function getAdvisory(status) {
@@ -148,8 +162,15 @@ if (typeof _showAll === "undefined") {
     }
 
     function buildSuggestedValidateCommand(databaseName, collectionName) {
+        // Namespaces may contain newlines, which would break out of the quoted literal when pasted into mongosh.
         function escapeSingleQuotedLiteral(value) {
-            return String(value).replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+            return String(value)
+                .replace(/\\/g, "\\\\")
+                .replace(/'/g, "\\'")
+                .replace(/\n/g, "\\n")
+                .replace(/\r/g, "\\r")
+                .replace(/\u2028/g, "\\u2028")
+                .replace(/\u2029/g, "\\u2029");
         }
 
         var safeDatabaseName = escapeSingleQuotedLiteral(databaseName);
@@ -158,17 +179,14 @@ if (typeof _showAll === "undefined") {
         return "db.getSiblingDB('" + safeDatabaseName + "').getCollection('" + safeCollectionName + "').validate({full:true}).warnings";
     }
 
+    function isCandidateIndex(indexSpec) {
+        return indexSpec.unique === true && indexSpec.name !== "_id_";
+    }
+
+    // Callers must pre-filter index specs with isCandidateIndex.
     function validateIndex(databaseName, collectionName, indexSpec, stats) {
-        if (indexSpec.name === "_id_") {
-            return null;
-        }
-
-        if (indexSpec.unique !== true) {
-            return null;
-        }
-
         var formatVersions = getFormatVersions(stats, indexSpec.name);
-        var status = classifyFormatVersions(formatVersions);
+        var status = classifyFormatVersions(formatVersions.versions, formatVersions.unknownLocations);
 
         var advisory = getAdvisory(status);
         var result = {
@@ -177,7 +195,8 @@ if (typeof _showAll === "undefined") {
             namespace: databaseName + "." + collectionName,
             indexName: indexSpec.name || "<unnamed>",
             key: indexSpec.key || "<unknown key pattern>",
-            formatVersions: Object.keys(formatVersions).length ? formatVersions : "unknown",
+            formatVersions: formatVersions.versions,
+            unknownLocations: formatVersions.unknownLocations,
             status: status
         };
 
@@ -206,31 +225,56 @@ if (typeof _showAll === "undefined") {
         var errors = [];
         var databases = getUserDatabases();
 
+        function recordError(databaseName, collectionName, e) {
+            var error = {
+                scope: collectionName ? "collection" : "database",
+                db: databaseName,
+                error: e.message
+            };
+
+            if (collectionName) {
+                error.collection = collectionName;
+                error.namespace = databaseName + "." + collectionName;
+            }
+
+            errors.push(error);
+        }
+
         databases.forEach(function (databaseInfo) {
             var currentDb = db.getSiblingDB(databaseInfo.name);
+            var collectionNames;
 
-            getCollectionNames(currentDb).forEach(function (collectionName) {
-                var currentCollection = currentDb.getCollection(collectionName);
+            try {
+                collectionNames = getCollectionNames(currentDb);
+            } catch (e) {
+                recordError(databaseInfo.name, null, e);
+                return;
+            }
+
+            collectionNames.forEach(function (collectionName) {
+                var candidateIndexes;
                 var stats;
+
+                try {
+                    candidateIndexes = currentDb.getCollection(collectionName).getIndexes().filter(isCandidateIndex);
+                } catch (e) {
+                    recordError(databaseInfo.name, collectionName, e);
+                    return;
+                }
+
+                if (!candidateIndexes.length) {
+                    return;
+                }
 
                 try {
                     stats = getIndexDetails(currentDb, collectionName);
                 } catch (e) {
-                    errors.push({
-                        db: databaseInfo.name,
-                        collection: collectionName,
-                        namespace: databaseInfo.name + "." + collectionName,
-                        error: e.message
-                    });
+                    recordError(databaseInfo.name, collectionName, e);
                     return;
                 }
 
-                currentCollection.getIndexes().forEach(function (indexSpec) {
-                    var result = validateIndex(databaseInfo.name, collectionName, indexSpec, stats);
-
-                    if (result) {
-                        results.push(result);
-                    }
+                candidateIndexes.forEach(function (indexSpec) {
+                    results.push(validateIndex(databaseInfo.name, collectionName, indexSpec, stats));
                 });
             });
         });


### PR DESCRIPTION
## Summary

Adds the unique index format validation tool for MIGRATION-754.

The tool is located under:

migration/toolbox/indexFormatValidation/

It validates unique non-_id_ indexes and identifies index formats that require review before migration.

## Testing

- Verified JavaScript syntax with `node --check`
- Ran the script with test input
- Verified staged changes with `git diff --cached --check`

## Files

- `migration/toolbox/indexFormatValidation/indexFormatValidation.js`
- `migration/toolbox/indexFormatValidation/README.md`
- Updated `migration/toolbox/README.md`
